### PR TITLE
Features and bugs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2018.07.09',
+      version='2018.07.10',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/vlab_inf_common/vmware/ova.py
+++ b/vlab_inf_common/vmware/ova.py
@@ -184,6 +184,9 @@ class Ova(object):
             if lease.state not in ('done', 'error'):
                 self._chime_progress(lease)
             self._prog = prog
+        except vmodl.fault.ManagedObjectNotFound:
+            # race between upload completing, and Timer chiming
+            pass
         except Exception:
             # Don't start a new chimer, write the traceback to the console,
             # and kill the deploy. Might take a few moments for the deploy


### PR DESCRIPTION
Found all this stuff out _the hard way_ when creating a Celery worker for deploying an OVA.

**The Bug**
Turns out that there's a bug when not deploying an OVA via a simple script. When the deploy logic is finished, it destroys the task. However, the Timer that updates the progress bar is still alive, and will attempt to reference the task. This would cause pyVmomi to raise an exception.

**The Feature**
Using VMTools and pyVmomi to run a command in a VM is a bit of a pain, especially if you just powered on a VM. The new `run_command` function will auto-magically handle this for you. The `init_timeout` parameter defines how long to wait for VMTools to be available (we'll poke the VM once second until VMTools is ready).