### PR TITLE
vCenter no longer assumes things exist in the root folder

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2018.07.12',
+      version='2018.07.13',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/tests/test_vcenter.py
+++ b/tests/test_vcenter.py
@@ -7,11 +7,13 @@ from unittest.mock import MagicMock, patch
 
 from vlab_inf_common.vmware import vcenter
 
+
 class FakeObj(object):
     """An object with arbitrary names and values for testing"""
     def __init__(self, **kwargs):
         for name, value in kwargs.items():
             setattr(self, name, value)
+
 
 class TestMapObject(unittest.TestCase):
     """
@@ -114,7 +116,7 @@ class TestvCenter(vCenterBase):
         self.assertEqual(result, fake_obj1)
 
     @patch.object(vcenter, 'connect')
-    def test_creat_vm_folder(self, fake_connect):
+    def test_create_vm_folder(self, fake_connect):
         """vCenter - ``create_vm_folder`` can create a root folder"""
         fake_entity = MagicMock()
         vc = vcenter.vCenter(host='localhost', user='bob', password='iLoveKats')
@@ -126,18 +128,17 @@ class TestvCenter(vCenterBase):
 
     @patch.object(vcenter.vCenter, 'get_by_name')
     @patch.object(vcenter, 'connect')
-    def test_creat_vm_folder_datacenter(self, fake_connect, fake_get_by_name):
+    def test_create_vm_folder_datacenter(self, fake_connect, fake_get_by_name):
         """vCenter - ``create_vm_folder`` accepts the datacenter as a param"""
         fake_entity = MagicMock()
+        fake_entity.name = 'someDC'
         vc = vcenter.vCenter(host='localhost', user='bob', password='iLoveKats')
         vc._conn = self._fake_conn_factory(fake_entity)
+        vc.content.rootFolder.childEntity = [fake_entity]
 
         result = vc.create_vm_folder('/foo/bar', datacenter='someDC')
 
         self.assertEqual(result, None)
-        self.assertTrue(fake_get_by_name.called)
-
-
 
     @patch.object(vcenter.vCenter, 'get_by_name')
     @patch.object(vcenter, 'connect')
@@ -148,7 +149,7 @@ class TestvCenter(vCenterBase):
         vc._conn = self._fake_conn_factory(fake_entity)
 
         with self.assertRaises(FileNotFoundError):
-            vc.get_vm_folder('/foo/bar', datacenter='someDC')
+            vc.get_vm_folder('/foo/bar')
 
 
 class TestvCenterProperties(vCenterBase):

--- a/vlab_inf_common/constants.py
+++ b/vlab_inf_common/constants.py
@@ -14,7 +14,7 @@ DEFINED = OrderedDict([
             ('INF_VCENTER_CONSOLE_PORT', int(environ.get('INF_VCENTER_CONSOLE_PORT', 9443))),
             ('INF_VCENTER_USER', environ.get('INF_VCENTER_SERVER', 'tester')),
             ('INF_VCENTER_PASSWORD', environ.get('INF_VCENTER_PASSWORD', 'a')),
-            ('INF_VCENTER_TOP_LVL_DIR', environ.get('INF_VCENTER_TOP_LVL_DIR', 'vlab')),
+            ('INF_VCENTER_TOP_LVL_DIR', environ.get('INF_VCENTER_TOP_LVL_DIR', '/')),
             ('INF_LOG_LEVEL', environ.get('INF_LOG_LEVEL', 'INFO')),
             ('INF_VCENTER_TEMPLATES_DIR', environ.get('INF_VCENTER_TEMPLATES_DIR', 'vlab/templates')),
             ('INF_VCENTER_OVA_HOME', environ.get('INF_VCENTER_OVA_HOME', 'http://localhost/ovas')),


### PR DESCRIPTION
I started to notice a lot of duplicate code in every service, which is creating some gremlins.
Instead of requiring every service to manage the location of the folder that holds all a user's VMs, I figured jamming that logic into the `vCenter` object made the most sense. Now, the services just have to define the base directory via the env var `INF_VCENTER_TOP_LVL_DIR`. 