### PR TITLE
task view now accepts v2 tokens

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2018.07.18',
+      version='2018.09.20',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/vlab_inf_common/views/task_view.py
+++ b/vlab_inf_common/views/task_view.py
@@ -27,7 +27,7 @@ class TaskView(BaseView):
 
     @route('/task', methods=["GET"])
     @route('/task/<tid>', methods=["GET"])
-    @requires(verify=False)
+    @requires(verify=False, version=(1,2))
     @describe(get_args=TASK_ARGS)
     def handle_task(self, *args, **kwargs):
         """End point for checking the status of Celery tasks


### PR DESCRIPTION
No token inspection beyond looking at the `username` occurs, so it's safe to use both v1 and v2 tokens.

We'll have to rev the API version when deprecating the use of v1 tokens because that will break backwards compatibility. 