### PR TITLE
binding meta data to dict is simpler

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2018.12.11',
+      version='2018.12.19',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/vlab_inf_common/vmware/virtual_machine.py
+++ b/vlab_inf_common/vmware/virtual_machine.py
@@ -87,7 +87,6 @@ def get_info(vcenter, the_vm, ensure_ip=True, ensure_timeout=600):
                      'generation': 0,
                      'configured': False
                      }
-        info['meta'] = meta_data
     info['meta'] = meta_data
     return info
 

--- a/vlab_inf_common/vmware/virtual_machine.py
+++ b/vlab_inf_common/vmware/virtual_machine.py
@@ -78,7 +78,7 @@ def get_info(vcenter, the_vm, ensure_ip=True, ensure_timeout=600):
     info['console'] = _get_vm_console_url(vcenter, the_vm)
     info['ips'] = _get_vm_ips(the_vm, ensure_ip, ensure_timeout)
     if the_vm.config:
-        info['meta'] = ujson.loads(the_vm.config.annotation)
+        meta_data = ujson.loads(the_vm.config.annotation)
     else:
         # A VM being deployed has no config
         meta_data = {'component': 'Unknown',
@@ -88,6 +88,7 @@ def get_info(vcenter, the_vm, ensure_ip=True, ensure_timeout=600):
                      'configured': False
                      }
         info['meta'] = meta_data
+    info['meta'] = meta_data
     return info
 
 

--- a/vlab_inf_common/vmware/virtual_machine.py
+++ b/vlab_inf_common/vmware/virtual_machine.py
@@ -73,10 +73,10 @@ def get_info(vcenter, the_vm, ensure_ip=True, ensure_timeout=600):
     :param ensure_timeout: How long to wait on an IP in seconds
     :type ensure_timeout: Integer
     """
-    info = {}
-    info['state'] = the_vm.runtime.powerState
-    info['console'] = _get_vm_console_url(vcenter, the_vm)
-    info['ips'] = _get_vm_ips(the_vm, ensure_ip, ensure_timeout)
+    details = {}
+    details['state'] = the_vm.runtime.powerState
+    details['console'] = _get_vm_console_url(vcenter, the_vm)
+    details['ips'] = _get_vm_ips(the_vm, ensure_ip, ensure_timeout)
     if the_vm.config:
         meta_data = ujson.loads(the_vm.config.annotation)
     else:
@@ -87,8 +87,8 @@ def get_info(vcenter, the_vm, ensure_ip=True, ensure_timeout=600):
                      'generation': 0,
                      'configured': False
                      }
-    info['meta'] = meta_data
-    return info
+    details['meta'] = meta_data
+    return details
 
 
 def set_meta(the_vm, meta_data):


### PR DESCRIPTION
Honestly, this PR is mostly to help debug WTF is going on with the v2 Beta images. Some are still encoding the meta data as a _double JSON_, others don't seem to be decoding it correctly.

This update cleans up the logic a bit, but mostly, lets me bump the version number so I can sanity check that _the right version in installed_ on the beta server images.