### PR TITLE
ensure_ip defaults to False now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2018.12.19',
+      version='2018.12.28',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/vlab_inf_common/vmware/virtual_machine.py
+++ b/vlab_inf_common/vmware/virtual_machine.py
@@ -56,7 +56,7 @@ def power(the_vm, state, timeout=600):
     return True
 
 
-def get_info(vcenter, the_vm, ensure_ip=True, ensure_timeout=600):
+def get_info(vcenter, the_vm, ensure_ip=False, ensure_timeout=600):
     """Obtain basic information about a virtual machine
 
     :Returns: Dictionary


### PR DESCRIPTION
Blocking on an IP really only makes sense for a brand new VM deployment. Deleting and showing also call this function, and they should not block on an IP (because the VM could be powered off, or a user could remove all IPs on the VM). Changing the default value to `False` means that it wont be overridden as much, and defaults should always be _the most common value_ for parameters.