### PR TITLE
Users can define multiple datastores for deployment needs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2019.02.21',
+      version='2019.02.25',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,24 @@
+# -*- coding: UTF-8 -*-
+"""A unit tests for the constants.py module"""
+import unittest
+
+from vlab_inf_common.constants import const
+
+
+class TestConstants(unittest.TestCase):
+    """A suite of test cases for the constants.py module"""
+
+    def test_expected_const(self):
+        """``const`` has the expected constants defined"""
+        found = [x for x in dir(const) if x.isupper()]
+        expected = ['INF_LOG_LEVEL', 'INF_VCENTER_CONSOLE_PORT', 'INF_VCENTER_DATASTORE', 'INF_VCENTER_OVA_HOME', 'INF_VCENTER_PASSWORD', 'INF_VCENTER_PORT', 'INF_VCENTER_RESORUCE_POOL', 'INF_VCENTER_SERVER', 'INF_VCENTER_TEMPLATES_DIR', 'INF_VCENTER_TOP_LVL_DIR', 'INF_VCENTER_USER', 'INF_VCENTER_VERIFY_CERT', 'VLAB_URL']
+
+        self.assertEqual(set(found), set(expected))
+
+    def test_datastore_type(self):
+        """``const.INF_VCENTER_DATASTORE`` is a list of usable datastores"""
+        self.assertTrue(isinstance(const.INF_VCENTER_DATASTORE, list))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vlab_inf_common/constants.py
+++ b/vlab_inf_common/constants.py
@@ -15,7 +15,7 @@ DEFINED = OrderedDict([
             ('INF_VCENTER_USER', environ.get('INF_VCENTER_SERVER', 'tester')),
             ('INF_VCENTER_PASSWORD', environ.get('INF_VCENTER_PASSWORD', 'a')),
             ('INF_VCENTER_TOP_LVL_DIR', environ.get('INF_VCENTER_TOP_LVL_DIR', '/')),
-            ('INF_VCENTER_DATASTORE', environ.get('INF_VCENTER_DATASTORE', 'VM-Storage')),
+            ('INF_VCENTER_DATASTORE', environ.get('INF_VCENTER_DATASTORE', 'VM-Storage').split(',')),
             ('INF_VCENTER_RESORUCE_POOL', environ.get('INF_VCENTER_RESORUCE_POOL', 'Resources')),
             ('INF_LOG_LEVEL', environ.get('INF_LOG_LEVEL', 'INFO')),
             ('INF_VCENTER_TEMPLATES_DIR', environ.get('INF_VCENTER_TEMPLATES_DIR', 'vlab/templates')),

--- a/vlab_inf_common/vmware/virtual_machine.py
+++ b/vlab_inf_common/vmware/virtual_machine.py
@@ -305,7 +305,7 @@ def deploy_from_ova(vcenter, ova, network_map, username, machine_name, logger, p
 
     folder = vcenter.get_by_name(name=username, vimtype=vim.Folder)
     resource_pool = vcenter.resource_pools[const.INF_VCENTER_RESORUCE_POOL]
-    datastore = vcenter.datastores[const.INF_VCENTER_DATASTORE]
+    datastore = vcenter.datastores[random.choice(const.INF_VCENTER_DATASTORE)]
     host = random.choice(list(vcenter.host_systems.values()))
     spec_params = vim.OvfManager.CreateImportSpecParams(entityName=machine_name,
                                                         networkMapping=network_map)


### PR DESCRIPTION
As the production roll-out looms, something occurred to me. Having all VMDKs rely on a single, massive LUN seems like _a bad idea_. To address that, this PR adds the functionality for users to define the datastore as a comma-separated list-o-things. Which datastore is used at deploy time is chosen randomly, which given enough time, is the same as round-robbin distribution, but with less code. 

By breaking up the back-end storage, vLab creates some bulk-heading between a [few] clients pounding on their VMDKs, and every user's VM becoming _slow_.