### PR TITLE
vCenter is more generic about supported TLS ciphers now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2019.02.25',
+      version='2019.03.18',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/vlab_inf_common/ssl_context.py
+++ b/vlab_inf_common/ssl_context.py
@@ -5,7 +5,7 @@ from vlab_inf_common.constants import const
 
 def get_context():
     if const.INF_VCENTER_VERIFY_CERT is False:
-        context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS)
         context.verify_mode = ssl.CERT_NONE
     else:
         context = ssl.create_default_context()


### PR DESCRIPTION
Not sure why I originally limited to strictly TLS 1.0... Now, the vCenter object will accept TLS 1.0 -> 1.2, and the `ssl` lib and the literal vcenter server will negotiate the strongest possible cipher.