### PR TITLE
resource_pools now refs the compute cluster

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2019.03.18',
+      version='2019.03.19',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/vlab_inf_common/vmware/vcenter.py
+++ b/vlab_inf_common/vmware/vcenter.py
@@ -226,7 +226,7 @@ class vCenter(object):
 
         :Returns: Dictionary
         """
-        return _map_object(self.get_by_type(vim.ResourcePool))
+        return _map_object(self.get_by_type(vim.ComputeResource))
 
     @property
     def datastores(self):


### PR DESCRIPTION
To deploy to the compute cluster I had to update the type of object `resource_pools` references.