### PR TITLE
Fixed datastore type... don't get why pymomi sucks like this...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2019.03.21',
+      version='2019.03.22',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/vlab_inf_common/vmware/virtual_machine.py
+++ b/vlab_inf_common/vmware/virtual_machine.py
@@ -306,6 +306,8 @@ def deploy_from_ova(vcenter, ova, network_map, username, machine_name, logger, p
     folder = vcenter.get_by_name(name=username, vimtype=vim.Folder)
     resource_pool = vcenter.resource_pools[const.INF_VCENTER_RESORUCE_POOL]
     datastore = vcenter.datastores[random.choice(const.INF_VCENTER_DATASTORE)]
+    if isinstance(datastore, vim.StoragePod):
+        datastore = random.choice(datastore.childEntity)
     host = random.choice(list(vcenter.host_systems.values()))
     spec_params = vim.OvfManager.CreateImportSpecParams(entityName=machine_name,
                                                         networkMapping=network_map)


### PR DESCRIPTION
Honestly, I don't get why it doesn't have a _just works_ API. I get that static typing is handy, but dear lord, a generic API should be able to consume similarly typed objects, especially when those similar objects can access the same root type.

TL;DR - Deploying an OVA requires `vim.Datastore`, even though `vim.StoragePod` can access all the `vim.Datastore`s that are within it. 