### PR TITLE
Bug fix: OpenSSL.crypto.load_certificate returns bytes now-a-days

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2019.03.22',
+      version='2019.03.28',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/tests/test_virtual_machine.py
+++ b/tests/test_virtual_machine.py
@@ -18,7 +18,7 @@ class TestVirtualMachine(unittest.TestCase):
     @patch.object(virtual_machine.ssl, 'get_server_certificate')
     def test_get_vm_console_url(self, fake_get_server_certificate, fake_load_certificate):
         """``virtual_machine`` - _get_vm_console_url returns the expected string"""
-        fake_load_certificate.return_value.digest.return_value = 'test-thumbprint'
+        fake_load_certificate.return_value.digest.return_value = b'test-thumbprint'
         item = MagicMock()
         item.key = 'VirtualCenter.FQDN'
         item.value = 'my.test.fqdn'

--- a/vlab_inf_common/vmware/virtual_machine.py
+++ b/vlab_inf_common/vmware/virtual_machine.py
@@ -162,7 +162,7 @@ def _get_vm_console_url(vcenter, the_vm):
     """
     fqdn = None
     vcenter_cert = ssl.get_server_certificate((const.INF_VCENTER_SERVER, const.INF_VCENTER_PORT))
-    thumbprint = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, vcenter_cert).digest('sha1')
+    thumbprint = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, vcenter_cert).digest('sha1').decode()
     server_guid = vcenter.content.about.instanceUuid
     session = vcenter.content.sessionManager.AcquireCloneTicket()
     for item in vcenter.content.setting.setting:


### PR DESCRIPTION
Not sure in what version of the OpenSSL lib this changed, but instead of returning a string, `OpenSSL.crypto.load_certificate` now returns bytes.

Noticed this while debugging why OneFS auto-configs were failing by looking at the console URL created by vLab, and what I get from a simple copy/paste via the vCenter browser.

vCenter's URL: `thumbprint=73:18:E3:B9:E9:86:C2:3D:06:2F:BF:8A:81:93:C9:11:6C:E7:EC:33&locale=en-US`
vLabs's URL: `thumbprint=b'73:18:E3:B9:E9:86:C2:3D:06:2F:BF:8A:81:93:C9:11:6C:E7:EC:33'`