### PR TITLE
The URI for the VM HTML5 console changed in vSphere 6.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2019.03.28',
+      version='2019.03.29',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/tests/test_virtual_machine.py
+++ b/tests/test_virtual_machine.py
@@ -31,7 +31,7 @@ class TestVirtualMachine(unittest.TestCase):
         vm.name = 'test-vm-name'
 
         console_url = virtual_machine._get_vm_console_url(vcenter=vcenter, the_vm=vm)
-        expected_url = 'https://localhost:9443/vsphere-client/webconsole.html?vmId=test-vm-id&vmName=test-vm-name&serverGuid=Test-UUID&locale=en_US&host=localhost:443&sessionTicket=test-session&thumbprint=test-thumbprint'
+        expected_url = 'https://localhost/ui/webconsole.html?vmId=test-vm-id&vmName=test-vm-name&serverGuid=Test-UUID&locale=en_US&host=localhost&sessionTicket=test-session&thumbprint=test-thumbprint'
 
         self.assertEqual(console_url, expected_url)
 

--- a/vlab_inf_common/vmware/virtual_machine.py
+++ b/vlab_inf_common/vmware/virtual_machine.py
@@ -171,14 +171,12 @@ def _get_vm_console_url(vcenter, the_vm):
             break
 
     url = """\
-    https://{0}:{1}/vsphere-client/webconsole.html?vmId={2}&vmName={3}&serverGuid={4}&
-    locale=en_US&host={0}:{5}&sessionTicket={6}&thumbprint={7}
+    https://{0}/ui/webconsole.html?vmId={1}&vmName={2}&serverGuid={3}&
+    locale=en_US&host={0}&sessionTicket={4}&thumbprint={5}
     """.format(const.INF_VCENTER_SERVER,
-               const.INF_VCENTER_CONSOLE_PORT,
                the_vm._moId,
                the_vm.name,
                server_guid,
-               const.INF_VCENTER_PORT,
                session,
                thumbprint)
     return textwrap.dedent(url).replace('\n', '')


### PR DESCRIPTION
The old console links for vSphere 6.5 no longer work in vSphere 6.7.
This PR updates the URI so OneFS can be _auto configured_ again, but at the same time, breaks the URI for users _just clicking the console link_.
I feel like this is OK for now given that the _auto config_ is way more popular; I can sort out the console link aspect later.