### PR TITLE
removed pointless logging when a task fails or errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2019.03.29',
+      version='2019.04.17',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/vlab_inf_common/views/task_view.py
+++ b/vlab_inf_common/views/task_view.py
@@ -54,12 +54,10 @@ class TaskView(BaseView):
             # We use this to determine if the task was OK, the user supplied bad
             # input, or there's a system failure when running the task.
             if result.result['error']:
-                logger.error("Task {} failed: {}".format(task_id, result.result))
                 resp['error'] = result.result['error']
                 return ujson.dumps(resp), 400
             return ujson.dumps(result.result), 200
         elif result.status == 'FAILURE':
-            logger.error("Task {} errored: {}".format(task_id, result.result))
             return ujson.dumps(resp), 500
         else:
             return ujson.dumps(resp), 202


### PR DESCRIPTION
Noticed that the API logs had some generic log messages in them. These messages are redundant, and will break the parsing logic for jamming the web-logs into ElasticSearch, so I just removed them.

Example of log:
```
onefs-api_1          | 10.157.145.130 - someUser[17/Apr/2019:21:54:19 -0000] "POST /api/1/inf/onefs? HTTP/1.1" 202 79 "None" "vLab CLI 2019.03.28 rid=d7b5c19b314d41d5ae73e900e05b54df"
onefs-api_1          | Task fd3ce267-03a5-4841-902c-0d0a392bb900 failed: {'content': {}, 'error': 'No network named doh_192.168.1.3', 'params': {}}
```

But this info is captured in the worker logs:
```
willhn@vlab:/etc/vlab$ docker-compose logs onefs-worker | grep 6905ea3f-deb6-4ddc-8e67-5ade2fc48522
onefs-worker_1       | [2019-04-17 21:57:08,358: WARNING/ForkPoolWorker-10] 2019-04-17 21:57:08,358 [a01b5bde8a8c4a87a44770112b2a5033] [6905ea3f-deb6-4ddc-8e67-5ade2fc48522]: Task starting
onefs-worker_1       | [2019-04-17 21:57:08,766: WARNING/ForkPoolWorker-10] 2019-04-17 21:57:08,765 [a01b5bde8a8c4a87a44770112b2a5033] [6905ea3f-deb6-4ddc-8e67-5ade2fc48522]: Task failed: No network named doh_192.168.1.3
onefs-worker_1       | [2019-04-17 21:57:08,766: WARNING/ForkPoolWorker-10] 2019-04-17 21:57:08,766 [a01b5bde8a8c4a87a44770112b2a5033] [6905ea3f-deb6-4ddc-8e67-5ade2fc48522]: Task complete
```
