### PR TITLE
VMs are deployed with thin provisioned disks now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2019.04.17',
+      version='2019.05.07',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/vlab_inf_common/vmware/virtual_machine.py
+++ b/vlab_inf_common/vmware/virtual_machine.py
@@ -308,6 +308,7 @@ def deploy_from_ova(vcenter, ova, network_map, username, machine_name, logger, p
         datastore = random.choice(datastore.childEntity)
     host = random.choice(list(vcenter.host_systems.values()))
     spec_params = vim.OvfManager.CreateImportSpecParams(entityName=machine_name,
+                                                        diskProvisioning='thin',
                                                         networkMapping=network_map)
     spec = vcenter.ovf_manager.CreateImportSpec(ovfDescriptor=ova.ovf,
                                                 resourcePool=resource_pool,


### PR DESCRIPTION
Noticed that the storage was being gobbled up, and when I started inspecting the VMs they all had thick provisioned disks.

Not sure why that's the default in [pyVmomi, vCenter], but it's now explicitly not ours.
Did a quick test with this code deploying InsightIQ; both disks were thin provisioned and the VM consumes ~3GB of disk space instead of ~80GB.