### PR TITLE
Failed deploy of VM doesn't break viewing lab

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2019.05.07',
+      version='2019.05.21',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/tests/test_virtual_machine.py
+++ b/tests/test_virtual_machine.py
@@ -126,6 +126,29 @@ class TestVirtualMachine(unittest.TestCase):
 
         self.assertEqual(info, expected_info)
 
+    @patch.object(virtual_machine, '_get_vm_ips')
+    @patch.object(virtual_machine, '_get_vm_console_url')
+    def test_get_info_note_none(self, fake_get_vm_console_url, fake_get_vm_ips):
+        """``virtual_machine`` - TODO"""
+        fake_get_vm_ips.return_value = ['192.168.1.1']
+        fake_get_vm_console_url.return_value = 'https://test-vm-url'
+        vm = MagicMock()
+        vm.runtime.powerState = 'on'
+        vm.config.annotation = None
+        vcenter = MagicMock()
+
+        info = virtual_machine.get_info(vcenter, vm)
+        expected_info = {'state': 'on',
+                         'console': 'https://test-vm-url',
+                         'ips': ['192.168.1.1'],
+                         'meta': {'component': 'Unknown',
+                                  'created': 0,
+                                  'version': 'Unknown',
+                                  'generation': 0,
+                                  'configured': False}}
+
+        self.assertEqual(info, expected_info)
+
     def test_set_meta(self):
         """``virtual_machine`` set_meta stores a JSON object as a VM annotation"""
         fake_task = MagicMock()

--- a/vlab_inf_common/vmware/virtual_machine.py
+++ b/vlab_inf_common/vmware/virtual_machine.py
@@ -80,7 +80,9 @@ def get_info(vcenter, the_vm, ensure_ip=False, ensure_timeout=600):
     if the_vm.config:
         try:
             meta_data = ujson.loads(the_vm.config.annotation)
-        except ValueError:
+        except (ValueError, TypeError):
+            # ValueError -> VM created, but notes not updated
+            # TypeError  -> VM failed to be created; notes are None
             meta_data = {'component': 'Unknown',
                          'created': 0,
                          'version': "Unknown",


### PR DESCRIPTION
This update fixes an issue defined in https://github.com/willnx/vlab/issues/21

Long story short, sometimes VMware would create _"zombie"_ VMs (before additional updates to vCenter 6.7). These VMs would be hung between finishing creation, and failing creation. As a result, they existed in a user's inventory, and could not be deleted until after rebooting vCenter. While they existed, attempts to run `vlab status` would generate a Server Error.

Even though vCenter has been updated, I lack faith that this type of error wont _come back_ as a result of a future MR of vCenter.