### PR TITLE
Added centeral function to adjust VM memory/RAM

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2019.05.21',
+      version='2019.05.22',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/tests/test_virtual_machine.py
+++ b/tests/test_virtual_machine.py
@@ -445,5 +445,20 @@ class TestVirtualMachine(unittest.TestCase):
                                        folder=MagicMock(),
                                        host=MagicMock())
 
+    @patch.object(virtual_machine, 'consume_task')
+    def test_adjust_ram(self, fake_consume_task):
+        """``virtual_machine`` - 'adjust_ram' reconfigures the VM"""
+        the_vm = MagicMock()
+
+        mb_of_ram = 1024
+        virtual_machine.adjust_ram(the_vm, mb_of_ram=mb_of_ram)
+
+        the_args, _ = the_vm.Reconfigure.call_args
+        config_spec = the_args[0]
+
+        self.assertTrue(the_vm.Reconfigure.called)
+        self.assertEqual(mb_of_ram, config_spec.memoryMB)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/vlab_inf_common/vmware/virtual_machine.py
+++ b/vlab_inf_common/vmware/virtual_machine.py
@@ -364,3 +364,26 @@ def _get_lease(resource_pool, import_spec, folder, host):
         error = 'Lease never because usable'
         raise RuntimeError(error)
     return lease
+
+
+
+def adjust_ram(the_vm, mb_of_ram):
+    """Set the amount of RAM for a VM
+
+    **IMPORTANT**
+    Most VMs are required to be powered off in order to adjust RAM.
+    Unless you know that your guest OS supports hot-swap RAM, power your VM off
+    before changing how much RAM it has.
+
+    :Returns: None
+
+    :param the_vm: The virtual machine to adjust RAM on
+    :type the_vm: vim.VirtualMachine
+
+    :param mb_of_ram: The number of MB of RAM/memory to give the virtual machine
+    :type mb_of_ram: Integer
+    """
+    config_spec = vim.vm.ConfigSpec()
+    config_spec.memoryMB = mb_of_ram
+
+    consume_task(the_vm.Reconfigure(config_spec))


### PR DESCRIPTION
In response to https://github.com/willnx/vlab/issues/27

OneFS also needs the OVA adjusted to have _enough ram to work._ 
So instead of duplicating this in every service that needs it, seemed more reasonable to just add it here.