### PR TITLE
Added support to update VM network

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2019.05.22',
+      version='2019.06.18',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/tests/test_api_schemas.py
+++ b/tests/test_api_schemas.py
@@ -1,0 +1,35 @@
+# -*- coding: UTF-8 -*-
+"""A suite of unit tests for the API schemas"""
+import unittest
+
+from jsonschema import Draft4Validator, validate, ValidationError
+
+from vlab_inf_common.views import task_view
+
+
+class TestTaskViewSchema(unittest.TestCase):
+    """A set of test cases for the TaskView schemas"""
+
+    def test_task_get_schema(self):
+        """The scheam defined for GET on /task is valid"""
+        try:
+            Draft4Validator.check_schema(task_view.TaskView.TASK_ARGS)
+            schema_valid = True
+        except RuntimeError:
+            schema_valid = False
+
+        self.assertTrue(schema_valid)
+
+    def test_network_put_schema(self):
+        """The schema defined for PUT on /network is valid"""
+        try:
+            Draft4Validator.check_schema(task_view.TaskView.NETWORK_SCHEMA)
+            schema_valid = True
+        except RuntimeError:
+            schema_valid = False
+
+        self.assertTrue(schema_valid)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -11,7 +11,13 @@ class TestConstants(unittest.TestCase):
     def test_expected_const(self):
         """``const`` has the expected constants defined"""
         found = [x for x in dir(const) if x.isupper()]
-        expected = ['INF_LOG_LEVEL', 'INF_VCENTER_CONSOLE_PORT', 'INF_VCENTER_DATASTORE', 'INF_VCENTER_OVA_HOME', 'INF_VCENTER_PASSWORD', 'INF_VCENTER_PORT', 'INF_VCENTER_RESORUCE_POOL', 'INF_VCENTER_SERVER', 'INF_VCENTER_TEMPLATES_DIR', 'INF_VCENTER_TOP_LVL_DIR', 'INF_VCENTER_USER', 'INF_VCENTER_VERIFY_CERT', 'VLAB_URL']
+        expected = ['INF_LOG_LEVEL', 'INF_VCENTER_CONSOLE_PORT',
+                    'INF_VCENTER_DATASTORE', 'INF_VCENTER_OVA_HOME',
+                    'INF_VCENTER_PASSWORD', 'INF_VCENTER_PORT',
+                    'INF_VCENTER_RESORUCE_POOL', 'INF_VCENTER_SERVER',
+                    'INF_VCENTER_TEMPLATES_DIR', 'INF_VCENTER_TOP_LVL_DIR',
+                    'INF_VCENTER_USER', 'INF_VCENTER_VERIFY_CERT',
+                    'VLAB_URL', 'VLAB_VERIFY_TOKEN']
 
         self.assertEqual(set(found), set(expected))
 

--- a/tests/test_task_view.py
+++ b/tests/test_task_view.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, MagicMock
 
 import ujson
 from flask import Flask
-from vlab_api_common.http_auth import generate_test_token
+from vlab_api_common.http_auth import generate_v2_test_token
 
 from vlab_inf_common.views import task_view
 
@@ -20,7 +20,7 @@ class TestTaskView(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Runs once for the whole suite"""
-        cls.token = generate_test_token(username='alice')
+        cls.token = generate_v2_test_token(username='alice')
 
     @classmethod
     def setUp(cls):

--- a/tests/test_task_view.py
+++ b/tests/test_task_view.py
@@ -13,6 +13,11 @@ from vlab_inf_common.views import task_view
 class MyView(task_view.TaskView):
     route_base = '/test'
 
+    def send_network_task(self, username, machine_name, new_network, txn_id):
+        """The base method is an abstractmethod"""
+        task = MagicMock()
+        task.id = 'aabbcc'
+        return task
 
 class TestTaskView(unittest.TestCase):
     """A set of test cases for ``TaskView``"""
@@ -83,6 +88,18 @@ class TestTaskView(unittest.TestCase):
                 headers={'X-Auth': self.token})
 
         self.assertEqual(resp.status_code, 400)
+
+    def test_modify_network(self):
+        """``TaskView`` - PUT on /network returns a task id"""
+        payload = {'name': "someVM", 'new_network': "myOtherNetwork"}
+
+        resp = self.app.put('/test/network',
+                            headers={'X-Auth': self.token},
+                            json=payload)
+
+        expected = {'error': None, 'content': {'task-id': 'aabbcc'}, 'params': {}}
+
+        self.assertEqual(resp.json, expected)
 
 
 if __name__ == '__main__':

--- a/tests/test_virtual_machine.py
+++ b/tests/test_virtual_machine.py
@@ -471,6 +471,39 @@ class TestVirtualMachine(unittest.TestCase):
         self.assertTrue(the_vm.Reconfigure.called)
         self.assertEqual(mb_of_ram, config_spec.memoryMB)
 
+    @patch.object(virtual_machine.vim.vm, 'ConfigSpec')
+    @patch.object(virtual_machine.vim.vm.device.VirtualDevice, 'ConnectInfo')
+    @patch.object(virtual_machine.vim.vm.device.VirtualEthernetCard, 'DistributedVirtualPortBackingInfo')
+    @patch.object(virtual_machine.vim.dvs, 'PortConnection')
+    @patch.object(virtual_machine.vim.vm.device, 'VirtualDeviceSpec')
+    @patch.object(virtual_machine, 'consume_task')
+    def test_change_network(self, fake_consume_task, fake_VirtualDeviceSpec, fake_PortConnection,
+                            fake_DistributedVirtualPortBackingInfo, fake_ConnectInfo,
+                            fake_ConfigSpec):
+        """``virtual_machine`` - 'change_network' returns None upon success"""
+        fake_network = MagicMock()
+        fake_nic = MagicMock()
+        fake_nic.deviceInfo.label = 'Network adapter 1'
+        the_vm = MagicMock()
+        the_vm.config.hardware.device = [fake_nic]
+
+        result = virtual_machine.change_network(the_vm, fake_network)
+        expected = None
+
+        self.assertTrue(result is None)
+
+    @patch.object(virtual_machine, 'consume_task')
+    def test_change_network_no_adapter(self, fake_consume_task):
+        """``virtual_machine`` - 'change_network' returns None upon success"""
+        fake_network = MagicMock()
+        fake_nic = MagicMock()
+        fake_nic.deviceInfo.label = 'Network adapter 7'
+        the_vm = MagicMock()
+        the_vm.config.hardware.device = [fake_nic]
+
+        with self.assertRaises(RuntimeError):
+            virtual_machine.change_network(the_vm, fake_network)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_virtual_machine.py
+++ b/tests/test_virtual_machine.py
@@ -47,6 +47,18 @@ class TestVirtualMachine(unittest.TestCase):
 
         self.assertEqual(ips, expected_ips)
 
+    def test__get_vm_ips_ipv6(self):
+        """``virtual_machine`` - _get_vm_ips does not return IPv6 Link Local IPs"""
+        nic = MagicMock()
+        nic.ipAddress = ['192.168.1.1', 'fe80::dead:beef']
+        vm = MagicMock()
+        vm.guest.net = [nic]
+
+        ips = virtual_machine._get_vm_ips(vm, ensure_ip=False, ensure_timeout=300)
+        expected_ips = ['192.168.1.1']
+
+        self.assertEqual(ips, expected_ips)
+
     @patch.object(virtual_machine.time, 'sleep')
     def test_vm_ips_runtime_error(self, fake_sleep):
         """``virtual_machine`` - _get_vm_ips raises RuntimeError if ensure_timeout is exceeded"""

--- a/vlab_inf_common/constants.py
+++ b/vlab_inf_common/constants.py
@@ -21,6 +21,7 @@ DEFINED = OrderedDict([
             ('INF_VCENTER_TEMPLATES_DIR', environ.get('INF_VCENTER_TEMPLATES_DIR', 'vlab/templates')),
             ('INF_VCENTER_OVA_HOME', environ.get('INF_VCENTER_OVA_HOME', 'http://localhost/ovas')),
             ('INF_VCENTER_VERIFY_CERT', environ.get('INF_VCENTER_VERIFY_CERT', False)),
+            ('VLAB_VERIFY_TOKEN', environ.get('VLAB_VERIFY_TOKEN', False)),
           ])
 
 Constants = namedtuple('Constants', list(DEFINED.keys()))

--- a/vlab_inf_common/views/task_view.py
+++ b/vlab_inf_common/views/task_view.py
@@ -7,6 +7,8 @@ from flask import current_app
 from flask_classy import request, route
 from vlab_api_common import describe, BaseView, requires, get_logger
 
+from vlab_inf_common.constants import const
+
 logger = get_logger(__name__, loglevel='INFO')
 
 
@@ -27,7 +29,7 @@ class TaskView(BaseView):
 
     @route('/task', methods=["GET"])
     @route('/task/<tid>', methods=["GET"])
-    @requires(verify=False, version=(1,2))
+    @requires(verify=const.VLAB_VERIFY_TOKEN, version=2)
     @describe(get_args=TASK_ARGS)
     def handle_task(self, *args, **kwargs):
         """End point for checking the status of Celery tasks

--- a/vlab_inf_common/views/task_view.py
+++ b/vlab_inf_common/views/task_view.py
@@ -1,11 +1,13 @@
 # -*- coding: UTF-8 -*-
 """
-TODO
+Defines the API for common infrastructure API end points
 """
+from abc import abstractmethod
+
 import ujson
 from flask import current_app
-from flask_classy import request, route
-from vlab_api_common import describe, BaseView, requires, get_logger
+from flask_classy import request, route, Response
+from vlab_api_common import describe, BaseView, requires, get_logger, validate_input
 
 from vlab_inf_common.constants import const
 
@@ -18,7 +20,7 @@ class TaskView(BaseView):
 	              "type": "object",
                   "properties": {
                      "task-id": {
-                         "descrition": "The Task Id. Optionally index the URL with the task id",
+                         "description": "The Task Id. Optionally index the URL with the task id",
                          "type": "string"
                      }
                    },
@@ -26,6 +28,20 @@ class TaskView(BaseView):
                       "task-id"
                    ]
                 }
+    NETWORK_SCHEMA = {"$schema": "http://json-schema.org/draft-04/schema#",
+	                  "type": "object",
+                      "properties": {
+                         "name": {
+                            "description": "The name of the virtual machine",
+                            "type": "string",
+                         },
+                         "new_network": {
+                            "description": "The name of the network to connect the VM to",
+                            "type": "string"
+                         }
+                      },
+                      "required": ["name", "new_network"]
+                     }
 
     @route('/task', methods=["GET"])
     @route('/task/<tid>', methods=["GET"])
@@ -63,3 +79,26 @@ class TaskView(BaseView):
             return ujson.dumps(resp), 500
         else:
             return ujson.dumps(resp), 202
+
+    @route('/network', methods=["PUT"])
+    @requires(verify=const.VLAB_VERIFY_TOKEN, version=2)
+    @validate_input(schema=NETWORK_SCHEMA)
+    @describe(put=NETWORK_SCHEMA)
+    def modify_network(self, *args, **kwargs):
+        """Change the network a virtual machine is connected to"""
+        username = kwargs['token']['username']
+        machine_name = kwargs['body']['name']
+        new_network = kwargs['body']['new_network']
+        txn_id = request.headers.get('X-REQUEST-ID', 'noId')
+        resp_data = {'user' : username}
+        task = self.send_network_task(username, machine_name, new_network, txn_id)
+        resp_data['content'] = {'task-id': task.id}
+        resp = Response(ujson.dumps(resp_data))
+        resp.status_code = 202
+        resp.headers.add('Link', '<{0}{1}/task/{2}>; rel=status'.format(const.VLAB_URL, self.route_base, task.id))
+        return resp
+
+    @abstractmethod
+    def send_network_task(self, username, machine_name, new_network, txn_id):
+        """Define how the specific component passes the task to the back-end workers"""
+        pass

--- a/vlab_inf_common/vmware/virtual_machine.py
+++ b/vlab_inf_common/vmware/virtual_machine.py
@@ -148,6 +148,9 @@ def _get_vm_ips(the_vm, ensure_ip, ensure_timeout):
         else:
             error = "Unable to obtain an IP within {} seconds".format(ensure_timeout)
             raise RuntimeError(error)
+    # No point is showing the IPv6 link local addrs if a firewall wont forward them
+    # https://en.wikipedia.org/wiki/Link-local_address
+    ips = [x for x in ips if not (x.startswith('fe80::') and x != '127.0.0.1')]
     return ips
 
 


### PR DESCRIPTION
This PR is part of the work needed for https://github.com/willnx/vlab/issues/29

While I was poking around this code, I realized that it was never updated to deprecate v1 auth tokens.
So after a bit of _touch up_, I added an end point so all the `inf` services would be forced to add support for changing a VMs network.

Handling this in the specific service makes the most sense, since not all VMs use the same adapter and what-not.