### PR TITLE
Better implamentation of /network API endpoint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2019.06.18',
+      version='2019.06.19',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/tests/test_api_schemas.py
+++ b/tests/test_api_schemas.py
@@ -23,7 +23,7 @@ class TestTaskViewSchema(unittest.TestCase):
     def test_network_put_schema(self):
         """The schema defined for PUT on /network is valid"""
         try:
-            Draft4Validator.check_schema(task_view.TaskView.NETWORK_SCHEMA)
+            Draft4Validator.check_schema(task_view.MachineView.NETWORK_SCHEMA)
             schema_valid = True
         except RuntimeError:
             schema_valid = False


### PR DESCRIPTION
As I started to update the services yesterday based off the changes in https://github.com/willnx/vlab_inf_common/pull/31, I started to see how bad of a solution that PR was.

This PR corrects that bad original implementation, by doing the right thing and putting that functionality into it's _own thing_. This way, the update doesn't break non-VM specific resources that still need to work asynchronously. 

Also, it's more automated, like instead of having an abstract method that does basically nothing, subclassers just have to define an attribute on the view.