### PR TITLE
Explictly deleting view object now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2019.07.12',
+      version='2019.11.29',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/vlab_inf_common/vmware/vcenter.py
+++ b/vlab_inf_common/vmware/vcenter.py
@@ -198,7 +198,9 @@ class vCenter(object):
         entity = self.content.viewManager.CreateContainerView(container=folder,
                                                               type=vimtype,
                                                               recursive=True)
-        return entity.view
+        answer = entity.view
+        entity.DestroyView()
+        return answer
 
     @property
     def content(self):


### PR DESCRIPTION
Not deleting this object causes the server to run out of memory for long running apps. This is because the server tracks and maintains an in-memory object for every view a client creates.

Not sure why this was never a problem before vCenter 6.7u3, but it really sucked to learn about this _the hard way_ 😢 