### PR TITLE
VM info include moId now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2019.11.29',
+      version='2019.12.05',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/tests/test_virtual_machine.py
+++ b/tests/test_virtual_machine.py
@@ -81,12 +81,14 @@ class TestVirtualMachine(unittest.TestCase):
         vm = MagicMock()
         vm.runtime.powerState = 'poweredOn'
         vm.config.annotation = '{"json": true}'
+        vm._moId = 'vm-1234'
         vcenter = MagicMock()
 
         info = virtual_machine.get_info(vcenter, vm, 'alice')
         expected_info = {'state': 'poweredOn',
                          'console': 'https://test-vm-url',
                          'ips': ['192.168.1.1'],
+                         'moid' : 'vm-1234',
                          'networks' : ['network1', 'network2'],
                          'meta': {'json': True}}
 
@@ -103,6 +105,7 @@ class TestVirtualMachine(unittest.TestCase):
         vm = MagicMock()
         vm.runtime.powerState = 'poweredOn'
         vm.config.annotation = ''
+        vm._moId = 'vm-1234'
         vcenter = MagicMock()
 
         info = virtual_machine.get_info(vcenter, vm, 'alice')
@@ -110,6 +113,7 @@ class TestVirtualMachine(unittest.TestCase):
                          'console': 'https://test-vm-url',
                          'ips': ['192.168.1.1'],
                          'networks' : ['network1', 'network2'],
+                         'moid' : 'vm-1234',
                          'meta': {'component': 'Unknown',
                                   'created': 0,
                                   'version': "Unknown",
@@ -131,12 +135,14 @@ class TestVirtualMachine(unittest.TestCase):
         vm = MagicMock()
         vm.runtime.powerState = 'poweredOn'
         vm.config = None
+        vm._moId = 'vm-1234'
         vcenter = MagicMock()
 
         info = virtual_machine.get_info(vcenter, vm, 'alice')
         expected_info = {'state': 'poweredOn',
                          'console': 'https://test-vm-url',
                          'ips': ['192.168.1.1'],
+                         'moid' : 'vm-1234',
                          'networks' : ['network1', 'network2'],
                          'meta': {'component': 'Unknown',
                                   'created': 0,
@@ -157,6 +163,7 @@ class TestVirtualMachine(unittest.TestCase):
         vm = MagicMock()
         vm.runtime.powerState = 'poweredOn'
         vm.config.annotation = None
+        vm._moId = 'vm-1234'
         vcenter = MagicMock()
 
         info = virtual_machine.get_info(vcenter, vm, 'alice')
@@ -164,6 +171,7 @@ class TestVirtualMachine(unittest.TestCase):
                          'console': 'https://test-vm-url',
                          'ips': ['192.168.1.1'],
                          'networks' : ['network1', 'network2'],
+                         'moid': 'vm-1234',
                          'meta': {'component': 'Unknown',
                                   'created': 0,
                                   'version': 'Unknown',

--- a/vlab_inf_common/vmware/virtual_machine.py
+++ b/vlab_inf_common/vmware/virtual_machine.py
@@ -80,6 +80,7 @@ def get_info(vcenter, the_vm, username, ensure_ip=False, ensure_timeout=600):
     details['console'] = _get_vm_console_url(vcenter, the_vm)
     details['ips'] = _get_vm_ips(the_vm, ensure_ip, ensure_timeout)
     details['networks'] = get_networks(vcenter, the_vm, username)
+    details['moid'] = the_vm._moId
     if the_vm.config:
         try:
             meta_data = ujson.loads(the_vm.config.annotation)


### PR DESCRIPTION
This PR makes pulling the `moid` of the VM easier via the API response from vLab.
The point of this PR is related to https://github.com/willnx/vlab/issues/53