### PR TITLE
ESXi hosts in MaintenanceMode are filtered out 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2019.12.05',
+      version='2020.02.27',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/tests/test_virtual_machine.py
+++ b/tests/test_virtual_machine.py
@@ -344,9 +344,10 @@ class TestVirtualMachine(unittest.TestCase):
         ova = MagicMock()
         fake_host = MagicMock()
         fake_host.name = 'host1'
+        fake_host.runtime.inMaintenanceMode = False
         vcenter = MagicMock()
         vcenter.get_by_name.return_value = fake_folder
-        vcenter.host_systems.values.return_value = [fake_host]
+        vcenter.host_systems = {'someHost': fake_host}
 
         result = virtual_machine.deploy_from_ova(vcenter=vcenter,
                                                  ova=ova,
@@ -397,9 +398,10 @@ class TestVirtualMachine(unittest.TestCase):
         ova = MagicMock()
         fake_host = MagicMock()
         fake_host.name = 'host1'
+        fake_host.runtime.inMaintenanceMode = False
         vcenter = MagicMock()
         vcenter.get_by_name.return_value = fake_folder
-        vcenter.host_systems.values.return_value = [fake_host]
+        vcenter.host_systems = {'someHost': fake_host}
 
         with self.assertRaises(RuntimeError):
             virtual_machine.deploy_from_ova(vcenter=vcenter,

--- a/vlab_inf_common/vmware/virtual_machine.py
+++ b/vlab_inf_common/vmware/virtual_machine.py
@@ -338,7 +338,8 @@ def deploy_from_ova(vcenter, ova, network_map, username, machine_name, logger, p
     datastore = vcenter.datastores[random.choice(const.INF_VCENTER_DATASTORE)]
     if isinstance(datastore, vim.StoragePod):
         datastore = random.choice(datastore.childEntity)
-    host = random.choice(list(vcenter.host_systems.values()))
+    all_hosts = [vcenter.host_systems[x] for x in vcenter.host_systems.keys() if not vcenter.host_systems[x].runtime.inMaintenanceMode]
+    host = random.choice(all_hosts)
     spec_params = vim.OvfManager.CreateImportSpecParams(entityName=machine_name,
                                                         diskProvisioning='thin',
                                                         networkMapping=network_map)


### PR DESCRIPTION
Before this PR, vLab could pick an ESXi host that was in Maintenance Mode as the host to deploy a VM onto. This would cause a deployment to fail, because VMs cannot exist on a host in Maintenance Mode.

With this update, hosts in Maintenance Mode are filtered out.