### PR TITLE
Bug ssl

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2020.02.27',
+      version='2020.03.18',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/vlab_inf_common/ssl_context.py
+++ b/vlab_inf_common/ssl_context.py
@@ -4,9 +4,8 @@ import ssl
 from vlab_inf_common.constants import const
 
 def get_context():
+    context = ssl.create_default_context()
     if const.INF_VCENTER_VERIFY_CERT is False:
-        context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+        context.check_hostname = False
         context.verify_mode = ssl.CERT_NONE
-    else:
-        context = ssl.create_default_context()
     return context


### PR DESCRIPTION
This update allows the vCenter object to negotiate different versions of SSL/TLS when connecting to the vcenter server.

The old implementation required TLS 1, which is... not a good solution 😅. 