### PR TITLE
Added module that ensure user-supplied IPv4 network values are valid

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2020.03.18',
+      version='2020.03.27',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/tests/test_input_validators.py
+++ b/tests/test_input_validators.py
@@ -1,0 +1,54 @@
+# -*- coding: UTF-8 -*-
+"""A suite of unit tests for the ``input_validators.py`` module"""
+import unittest
+import ipaddress
+
+from vlab_inf_common import input_validators
+
+
+class TestNetworkConfigOk(unittest.TestCase):
+    """A suite of test cases for the ``network_config_ok`` function"""
+    def test_good_config(self):
+        """``network_config_ok`` returns a zero-length string when the config is good"""
+        error = input_validators.network_config_ok(ip='192.168.1.2',
+                                                   gateway='192.168.1.1',
+                                                   netmask='255.255.255.0')
+        expected = ''
+
+        self.assertEqual(error, expected)
+
+    def test_bad_config(self):
+        """``network_config_ok`` returns an string when the config is bad"""
+        error = input_validators.network_config_ok(ip='10.7.1.2',
+                                                   gateway='192.168.1.1',
+                                                   netmask='255.255.255.0')
+        expected = 'Static IP 10.7.1.2 is not part of network 192.168.1.0/24. Adjust your netmask and/or default gateway.'
+
+        self.assertEqual(error, expected)
+
+    def test_bad_network(self):
+        """``network_config_ok`` returns an string when the supplied gateway/subnet doesn't make sense"""
+        error = input_validators.network_config_ok(ip='10.7.1.2',
+                                                   gateway='192.168.1.1',
+                                                   netmask='9.9.9.0')
+        expected = 'Default gateway 192.168.1.1 not part of subnet 9.9.9.0'
+
+        self.assertEqual(error, expected)
+
+
+class TestToNetwork(unittest.TestCase):
+    """A suite of test cases for the ``_to_network`` function"""
+    def test_return_type(self):
+        """``_to_network`` returns an IPv4Network object"""
+        gateway = '192.168.1.1'
+        netmask = '255.255.255.0'
+        cidr = '192.168.1.0/24'
+
+        network = input_validators._to_network(gateway, netmask)
+        expected = ipaddress.IPv4Network(cidr)
+
+        self.assertEqual(network, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vlab_inf_common/input_validators.py
+++ b/vlab_inf_common/input_validators.py
@@ -1,0 +1,52 @@
+# -*- coding: UTF-8 -*-
+"""A library for validating user input to the API"""
+import ipaddress
+
+
+def network_config_ok(ip, gateway, netmask):
+    """Validate that the supplied IPv4 network config is valid.
+
+    The return value is an error string. When the string has a length of zero,
+    that indicates zero errors (i.e. the config is valid).
+
+    :Returns: String
+
+    :param ip: The IP to validate as part of a network config
+    :type ip: String
+
+    :param gateway: The default gateway of the subnet
+    :type gateway: String
+
+    :param netmask: The subnet mask of the network, i.e. 255.255.255.0
+    :type netmask: String
+    """
+    error = ''
+    # default gateway must within supplied subnet, so lets assume that is the network
+    try:
+        network = _to_network(gateway, netmask)
+    except Exception:
+        error = 'Default gateway {} not part of subnet {}'.format(gateway, netmask)
+    else:
+        if not ipaddress.IPv4Address(ip) in list(network):
+            error = 'Static IP {} is not part of network {}. Adjust your netmask and/or default gateway.'.format(ip, network)
+    return error
+
+
+def _to_network(gateway, netmask):
+    """Convert an IP and subnet mask into CIDR format
+
+    :Returns: ipaddress.IPv4Network
+
+    :param gateway: The IPv4 address of the default gateway
+    :type gateway: String
+
+    :param netmask: The subnet mask of the network
+    :type netmask: String
+    """
+    ipaddr = gateway.split('.')
+    mask = netmask.split('.')
+    # to calculate network start do a bitwise AND of the octets between netmask and ip
+    net_start = '.'.join([str(int(ipaddr[x]) & int(mask[x])) for x in range(4)])
+    bit_count = sum([bin(int(x)).count("1") for x in netmask.split('.')])
+    cidr = '{}/{}'.format(net_start, bit_count)
+    return ipaddress.IPv4Network(cidr)


### PR DESCRIPTION
Some services are needing to accept network input from users.

Instead of defining similar/identical functions to validate that input in each service, I figured centralizing that logic here makes more sense.