### PR TITLE
Added function to adjust the number of CPUs a VM has

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2020.03.27',
+      version='2020.03.31',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/tests/test_virtual_machine.py
+++ b/tests/test_virtual_machine.py
@@ -492,6 +492,19 @@ class TestVirtualMachine(unittest.TestCase):
         self.assertTrue(the_vm.Reconfigure.called)
         self.assertEqual(mb_of_ram, config_spec.memoryMB)
 
+    @patch.object(virtual_machine, 'consume_task')
+    def test_adjust_cpu(self, fake_consume_task):
+        """``virtual_machine`` - 'adjust_cpu' reconfigures the VM"""
+        the_vm = MagicMock()
+        cpu_count = 8
+        virtual_machine.adjust_cpu(the_vm, cpu_count=cpu_count)
+
+        the_args, _ = the_vm.Reconfigure.call_args
+        config_spec = the_args[0]
+
+        self.assertTrue(the_vm.Reconfigure.called)
+        self.assertEqual(cpu_count, config_spec.numCPUs)
+
     @patch.object(virtual_machine.vim.vm, 'ConfigSpec')
     @patch.object(virtual_machine.vim.vm.device.VirtualDevice, 'ConnectInfo')
     @patch.object(virtual_machine.vim.vm.device.VirtualEthernetCard, 'DistributedVirtualPortBackingInfo')

--- a/vlab_inf_common/vmware/virtual_machine.py
+++ b/vlab_inf_common/vmware/virtual_machine.py
@@ -419,6 +419,24 @@ def adjust_ram(the_vm, mb_of_ram):
     consume_task(the_vm.Reconfigure(config_spec))
 
 
+def adjust_cpu(the_vm, cpu_count):
+    """Set the number of CPUs for a VM
+
+    **IMPORTANT**
+    Make sure your VM is powered off before calling this function, otherwise
+    it'll fail.
+
+    :param the_vm: The virtual machine to adjust CPU count on
+    :type the_vm: vim.VirtualMachine
+
+    :param cpu_count: The number of CPU cores to allocate to the VM
+    :type cpu_count: Integer
+    """
+    config_spec = vim.vm.ConfigSpec()
+    config_spec.numCPUs = cpu_count
+    consume_task(the_vm.Reconfigure(config_spec))
+
+
 def change_network(the_vm, network, adapter_label='Network adapter 1'):
     """Update the VM; replace existing network with the supplied network.
 


### PR DESCRIPTION
The DataIQ OVA doesn't ship with enough CPUs by default, so I have to adjust it _on the fly_.