### PR TITLE
Retry looking up a PID while VMware Tools is loading/starting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2020.03.31',
+      version='2020.04.01',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[


### PR DESCRIPTION
I wish this was a joke, but it's not 😞. Somehow, VMware Tools can be ready to run a command, but unavailable right after that for looking up a PID. This is the important chunk of a traceback that I'm getting when trying to add DataIQ to vLab. After rebooting the VM, I'm trying to install some packages, but keeps failing here:

```
dataiq-worker_1      | [2020-04-01 16:12:28,772: WARNING/ForkPoolWorker-8] File "/usr/lib/python3.6/site-packages/vlab_inf_common/vmware/virtual_machine.py", line 268, in run_command
dataiq-worker_1      |     info = get_process_info(vcenter, the_vm, user, password, pid)
dataiq-worker_1      | [2020-04-01 16:12:28,772: WARNING/ForkPoolWorker-8] File "/usr/lib/python3.6/site-packages/vlab_inf_common/vmware/virtual_machine.py", line 303, in get_process_info
dataiq-worker_1      |     pids=[pid])[0]
```

So, I tossed in a pile of retries... 🤞 