### PR TITLE
Can set a static IP/network for Windows and CentOS now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2020.04.01',
+      version='2020.04.13',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[


### PR DESCRIPTION
This isn't the most graceful solution, but it does edit the network config just like an admin would. The downside to using VMware Tools to set the config is that it's hidden. The configs that an admin would normally look at don't apply. Beyond that, the support across OSes in VMware Tools is... not great 😅.