### PR TITLE
Restarting NetworkManager.service to set static IP for CentOS 8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2020.04.14',
+      version='2020.04.15',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/tests/test_virtual_machine.py
+++ b/tests/test_virtual_machine.py
@@ -685,7 +685,7 @@ class TestConfigStaticIP(unittest.TestCase):
                                                password='IloveKatz!',
                                                logger=MagicMock())
 
-        self.assertEqual(fake_run_cmd.call_count, 3)
+        self.assertEqual(fake_run_cmd.call_count, 4)
 
     @patch.object(virtual_machine, 'run_command')
     def test_run_cmd(self, fake_run_command):

--- a/vlab_inf_common/vmware/virtual_machine.py
+++ b/vlab_inf_common/vmware/virtual_machine.py
@@ -595,9 +595,10 @@ def _config_centos8_network(vcenter, the_vm, static_ip, default_gateway, netmask
     GATEWAY={}
     NETMASK={}
     """.format(static_ip, default_gateway, netmask)
-    nic_config = '{}{}'.format(textwrap.dedent(config), _format_dns(dns))
+    nic_config = '{}{}\n'.format(textwrap.dedent(config), _format_dns(dns))
     _upload_nic_config(vcenter, the_vm, nic_config, os.path.basename(nic_config_file), user, password, logger)
     _run_cmd(vcenter, the_vm, '/bin/mv', '-f /tmp/{} {}'.format(os.path.basename(nic_config_file), nic_config_file), user, password, logger)
+    _run_cmd(vcenter, the_vm, '/usr/bin/systemctl', 'restart NetworkManager.service')
     _run_cmd(vcenter, the_vm, '/usr/bin/nmcli', 'connection down ens192 && /usr/bin/nmcli connection up ens192', user, password, logger)
     _run_cmd(vcenter, the_vm, '/bin/hostnamectl', 'set-hostname {}'.format(the_vm.name), user, password, logger)
 


### PR DESCRIPTION
No idea why, but if I don't restart `NetworkManager.service` before flipping the NIC down then up, then the IP doesn't take. 