### PR TITLE
Bug lease timeout

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2020.04.28',
+      version='2020.06.23',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/tests/test_virtual_machine.py
+++ b/tests/test_virtual_machine.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, PropertyMock, patch
 from pyVmomi import vim
 
 from vlab_inf_common.vmware import virtual_machine
+from vlab_inf_common.vmware.exceptions import DeployFailure
 
 
 class TestVirtualMachine(unittest.TestCase):
@@ -478,14 +479,14 @@ class TestVirtualMachine(unittest.TestCase):
 
     @patch.object(virtual_machine, 'time') # so test runs faster
     def test_get_lease_timeout(self, fake_time):
-        """``virtual_machine`` - _get_lease raises ValueError upon error"""
+        """``virtual_machine`` - _get_lease raises DeployFailure upon error"""
         fake_lease = MagicMock()
         fake_lease.error = None
         fake_lease.state = 'not ready'
         fake_resource_pool = MagicMock()
         fake_resource_pool.ImportVApp.return_value = fake_lease
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(DeployFailure):
             virtual_machine._get_lease(resource_pool=fake_resource_pool,
                                        import_spec=MagicMock(),
                                        folder=MagicMock(),

--- a/vlab_inf_common/vmware/exceptions.py
+++ b/vlab_inf_common/vmware/exceptions.py
@@ -1,0 +1,8 @@
+# -*- coding: UTF-8 -*-
+"""Custom exceptions"""
+
+# The existing code base excepts ValueError to gracefully handle the failure.
+# Subclassing that exception lets us raise unique errors, but not update a few
+# dozen services. Cheesy, yeah. Lazy, a bit. Worth the tech debt? I think so.
+class DeployFailure(ValueError):
+    pass

--- a/vlab_inf_common/vmware/ova.py
+++ b/vlab_inf_common/vmware/ova.py
@@ -250,7 +250,9 @@ class WebHandle(object):
         self.url = url
         r = urlopen(url)
         if r.code != 200:
-            raise FileNotFoundError(url)
+            version = os.path.splitext(os.path.basename(url))[0]
+            error = 'Unknown version supplied: {}'.format(version)
+            raise FileNotFoundError(error)
         self.headers = self._headers_to_dict(r)
         if 'accept-ranges' not in self.headers:
             err = "Server hosting remote OVA file does not support 'Accept-Ranges' HTTP header"


### PR DESCRIPTION
I've seen a sharp uptick in deployment failures, due to the deployment lease not being _ready_ after 30 seconds.

After some googling, I found that the default timeout for most tasks in vSphere is 15 minutes! I can't understand what in the hell vSphere is doing, where 30 seconds isn't enough time. Instead of going all the way to 15 minutes, I've increased the amount of time vLab will wait to 5 minutes. IMO, if a computer isn't going to do something in that amount of time, it's pointless to keep waiting. Just give up and try again!

I changed the kind of exception that gets raised to help direct users to _give up, and try again_. The error doesn't say that, but the vLab CLI will get a useful, consistent, specific error when it occurs. Changing the error allows all services to provide the specific error without having to update all of them. 

While I was poking around with error messages, I also updated the error a user will see when they supply an invalid version while deploying. Hopefully it'll reduce the amount of pings I get that are like, _"What does this error mean?"_ 