### PR TITLE
Added logic to export a VM to an OVA

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2020.06.23',
+      version='2020.11.11',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/tests/test_virtual_machine.py
+++ b/tests/test_virtual_machine.py
@@ -996,6 +996,7 @@ class TestVMExportFunctions(unittest.TestCase):
         self.assertEqual(sleep_call_count, expected_call_count)
         self.assertEqual(slept_for, expected_slept_for)
 
+    @patch.object(virtual_machine, 'power')
     @patch.object(virtual_machine, '_block_on_lease')
     @patch.object(virtual_machine, 'get_vm_ovf_xml')
     @patch.object(virtual_machine, 'download_vmdk')
@@ -1008,7 +1009,7 @@ class TestVMExportFunctions(unittest.TestCase):
     @patch.object(virtual_machine.shutil, 'rmtree')
     def test_make_ova(self, fake_rmtree, fake_listdir, fake_rename, fake_open,
         fake_sleep, fake_makedirs, fake_tarfile, fake_downlaod_vmdk, fake_get_vm_ovf_xml,
-        fake_block_on_lease):
+        fake_block_on_lease, fake_power):
         """``make_ova`` - Returns the location of the new OVA file"""
         fake_vcenter = MagicMock()
         fake_vm = MagicMock()
@@ -1020,6 +1021,7 @@ class TestVMExportFunctions(unittest.TestCase):
 
         self.assertEqual(output, expected)
 
+    @patch.object(virtual_machine, 'power')
     @patch.object(virtual_machine, '_block_on_lease')
     @patch.object(virtual_machine, 'get_vm_ovf_xml')
     @patch.object(virtual_machine, 'download_vmdk')
@@ -1032,7 +1034,7 @@ class TestVMExportFunctions(unittest.TestCase):
     @patch.object(virtual_machine.shutil, 'rmtree')
     def test_make_ova_downloads_all_vmdks(self, fake_rmtree, fake_listdir, fake_rename, fake_open,
         fake_sleep, fake_makedirs, fake_tarfile, fake_download_vmdk, fake_get_vm_ovf_xml,
-        fake_block_on_lease):
+        fake_block_on_lease, fake_power):
         """``make_ova`` - Downloads all the VMDKs of a virtual machine"""
         fake_vcenter = MagicMock()
         fake_vm = MagicMock()
@@ -1046,6 +1048,7 @@ class TestVMExportFunctions(unittest.TestCase):
 
         self.assertEqual(vmdks_downloaded, expected)
 
+    @patch.object(virtual_machine, 'power')
     @patch.object(virtual_machine, '_block_on_lease')
     @patch.object(virtual_machine, 'get_vm_ovf_xml')
     @patch.object(virtual_machine, 'download_vmdk')
@@ -1058,7 +1061,7 @@ class TestVMExportFunctions(unittest.TestCase):
     @patch.object(virtual_machine.shutil, 'rmtree')
     def test_make_ova_adds_all_files(self, fake_rmtree, fake_listdir, fake_rename, fake_open,
         fake_sleep, fake_makedirs, fake_tarfile, fake_download_vmdk, fake_get_vm_ovf_xml,
-        fake_block_on_lease):
+        fake_block_on_lease, fake_power):
         """``make_ova`` - adds all files to the OVA"""
         fake_vcenter = MagicMock()
         fake_vm = MagicMock()
@@ -1071,6 +1074,32 @@ class TestVMExportFunctions(unittest.TestCase):
         expected = 2
 
         self.assertEqual(files_added_to_ova, expected)
+
+    @patch.object(virtual_machine, 'power')
+    @patch.object(virtual_machine, '_block_on_lease')
+    @patch.object(virtual_machine, 'get_vm_ovf_xml')
+    @patch.object(virtual_machine, 'download_vmdk')
+    @patch.object(virtual_machine, 'tarfile')
+    @patch.object(virtual_machine.os, 'makedirs')
+    @patch.object(virtual_machine.time, 'sleep')
+    @patch.object(virtual_machine, 'open')
+    @patch.object(virtual_machine.os, 'rename')
+    @patch.object(virtual_machine.os, 'listdir')
+    @patch.object(virtual_machine.shutil, 'rmtree')
+    def test_make_ova_powers_off_vm(self, fake_rmtree, fake_listdir, fake_rename, fake_open,
+        fake_sleep, fake_makedirs, fake_tarfile, fake_download_vmdk, fake_get_vm_ovf_xml,
+        fake_block_on_lease, fake_power):
+        """``make_ova`` - Powers off the VM to create the export"""
+        fake_vcenter = MagicMock()
+        fake_vm = MagicMock()
+        fake_vm.name = 'myVM'
+        fake_log = MagicMock()
+
+        virtual_machine.make_ova(fake_vcenter, fake_vm, '/save/ova/here', fake_log)
+        the_args, _ = fake_power.call_args
+        expected  = (fake_vm, 'off')
+
+        self.assertEqual(the_args, expected)
 
 
 if __name__ == '__main__':

--- a/tests/test_virtual_machine.py
+++ b/tests/test_virtual_machine.py
@@ -803,6 +803,275 @@ class TestConfigStaticIP(unittest.TestCase):
                                             fake_file_size,
                                             fake_file_attributes)
 
+class TestVMExportFunctions(unittest.TestCase):
+    """A suite of test cases for functions used to create an OVA from an virtual machine"""
+
+    @patch.object(virtual_machine, 'open')
+    @patch.object(virtual_machine.requests, 'get')
+    def test_download_vmdk(self, fake_get, fake_open):
+        """``download_vmdk`` - Returns a list with a vim.OvfManager.OvfFile object when everything works as expected"""
+        fake_log = MagicMock()
+        fake_device = MagicMock()
+        fake_device.targetId = 'foo.vmdk'
+        fake_device.key = 'someKey'
+        fake_resp = MagicMock()
+        fake_resp.iter_content.return_value = [b'some', b'data']
+        fake_get.return_value = fake_resp
+        save_location = '/tmp'
+        http_cookies = {}
+
+        output = virtual_machine.download_vmdk(save_location, http_cookies, fake_device, fake_log)
+
+        self.assertEqual(1, len(output))
+        self.assertTrue(isinstance(output[0], virtual_machine.vim.OvfManager.OvfFile))
+
+    @patch.object(virtual_machine, 'open')
+    @patch.object(virtual_machine.requests, 'get')
+    def test_download_vmdk_error(self, fake_get, fake_open):
+        """``download_vmdk`` - Returns an empty list if the device is not a VMDK"""
+        fake_log = MagicMock()
+        fake_device = MagicMock()
+        fake_device.targetId = ''
+        fake_device.disk = False
+        fake_device.key = 'someKey'
+        fake_resp = MagicMock()
+        fake_resp.iter_content.return_value = [b'some', b'data']
+        fake_get.return_value = fake_resp
+        save_location = '/tmp'
+        http_cookies = {}
+
+        output = virtual_machine.download_vmdk(save_location, http_cookies, fake_device, fake_log)
+
+        self.assertEqual(0, len(output))
+
+    @patch.object(virtual_machine, 'open')
+    @patch.object(virtual_machine.requests, 'get')
+    def test_download_vmdk_skips_keepalive_blocks(self, fake_get, fake_open):
+        """``download_vmdk`` - Does not write empty blocks as the result of HTTP keepalives"""
+        fake_log = MagicMock()
+        fake_device = MagicMock()
+        fake_device.targetId = 'foo.vmdk'
+        fake_device.key = 'someKey'
+        fake_resp = MagicMock()
+        fake_resp.iter_content.return_value = [b'some', b'', b'data']
+        fake_get.return_value = fake_resp
+        save_location = '/tmp'
+        http_cookies = {}
+
+        virtual_machine.download_vmdk(save_location, http_cookies, fake_device, fake_log)
+        write_count = fake_open.return_value.__enter__.return_value.write.call_count
+        expected = 2
+
+        self.assertEqual(write_count, expected)
+
+    @patch.object(virtual_machine.vim.OvfManager, 'CreateDescriptorParams')
+    def test_get_vm_ovf_xml(self, fake_CreateDescriptorParams):
+        """``get_vm_ovf_xml`` returns a string when everything works as expected"""
+        fake_vm_ovf = MagicMock()
+        fake_vm_ovf.error = []
+        fake_vm_ovf.ovfDescriptor = '<some>xml</some>'
+        fake_vcenter = MagicMock()
+        fake_vcenter.content.ovfManager.CreateDescriptor.return_value = fake_vm_ovf
+        fake_vm = MagicMock()
+        fake_vm.name = 'myVM'
+        fake_device_ovfs = [MagicMock(), MagicMock()]
+
+        output = virtual_machine.get_vm_ovf_xml(fake_vm, fake_device_ovfs, fake_vcenter)
+        expected = fake_vm_ovf.ovfDescriptor
+
+        self.assertEqual(output, expected)
+
+    @patch.object(virtual_machine.vim.OvfManager, 'CreateDescriptorParams')
+    def test_get_vm_ovf_xml_error(self, fake_CreateDescriptorParams):
+        """``get_vm_ovf_xml`` Raises an exception when unable to create the OVF xml"""
+        fake_vm_ovf = MagicMock()
+        fake_error = MagicMock()
+        fake_error.fault = RuntimeError("testing")
+        fake_vm_ovf.error = [fake_error]
+        fake_vm_ovf.ovfDescriptor = '<some>xml</some>'
+        fake_vcenter = MagicMock()
+        fake_vcenter.content.ovfManager.CreateDescriptor.return_value = fake_vm_ovf
+        fake_vm = MagicMock()
+        fake_vm.name = 'myVM'
+        fake_device_ovfs = [MagicMock(), MagicMock()]
+
+        with self.assertRaises(RuntimeError):
+            virtual_machine.get_vm_ovf_xml(fake_vm, fake_device_ovfs, fake_vcenter)
+
+    @patch.object(virtual_machine.time, 'sleep')
+    def test_progress_chimer(self, fake_sleep):
+        """``ProgressChimer`` - Thread starts upon creation."""
+        fake_lease = MagicMock()
+        fake_log = MagicMock()
+        chimer = virtual_machine.ProgressChimer(fake_lease, fake_log)
+
+        self.assertTrue(chimer.isAlive())
+        chimer.complete()
+
+    @patch.object(virtual_machine.time, 'sleep')
+    def test_progress_chimer_completes(self, fake_sleep):
+        """``ProgressChimer`` - 'complete' blocks until the thread terminates"""
+        fake_lease = MagicMock()
+        fake_log = MagicMock()
+        chimer = virtual_machine.ProgressChimer(fake_lease, fake_log)
+
+        chimer.complete()
+
+        self.assertFalse(chimer.isAlive())
+
+    @patch.object(virtual_machine.time, 'sleep')
+    def test_progress_chimer_with_statement(self, fake_sleep):
+        """``ProgressChimer`` - support auto start/stop in a 'with' statement"""
+        fake_lease = MagicMock()
+        fake_log = MagicMock()
+
+        with virtual_machine.ProgressChimer(fake_lease, fake_log) as chimer:
+            self.assertTrue(chimer.isAlive())
+        self.assertFalse(chimer.isAlive())
+
+    @patch.object(virtual_machine.time, 'sleep')
+    def test_progress_chimer_lease_complete(self, fake_sleep):
+        """``ProgressChimer`` - complete terminates the NFC lease"""
+        fake_lease = MagicMock()
+        fake_log = MagicMock()
+        chimer = virtual_machine.ProgressChimer(fake_lease, fake_log)
+        chimer.complete()
+
+        self.assertTrue(chimer._lease.HttpNfcLeaseComplete.called)
+
+    @patch.object(virtual_machine.time, 'sleep')
+    def test_block_on_lease(self, fake_sleep):
+        """``_block_on_lease`` - waits for the NFS lease to be ready"""
+        fake_lease = MagicMock()
+        fake_lease.state = virtual_machine.vim.HttpNfcLease.State.ready
+
+        virtual_machine._block_on_lease(fake_lease)
+
+        self.assertFalse(fake_sleep.called)
+
+    @patch.object(virtual_machine.time, 'sleep')
+    def test_block_on_lease_blocks(self, fake_sleep):
+        """``_block_on_lease`` - blocks until the NFS lease is ready"""
+        fake_lease = MagicMock()
+        type(fake_lease).state = PropertyMock(side_effect=['', virtual_machine.vim.HttpNfcLease.State.ready, virtual_machine.vim.HttpNfcLease.State.ready])
+
+        virtual_machine._block_on_lease(fake_lease)
+
+        self.assertEqual(fake_sleep.call_count, 1)
+
+    @patch.object(virtual_machine.time, 'sleep')
+    def test_block_on_lease_error(self, fake_sleep):
+        """``_block_on_lease`` - Raises RuntimeError if the lease state is an error"""
+        fake_lease = MagicMock()
+        fake_lease.state = virtual_machine.vim.HttpNfcLease.State.error
+
+        with self.assertRaises(RuntimeError):
+            virtual_machine._block_on_lease(fake_lease)
+
+    @patch.object(virtual_machine.time, 'sleep')
+    def test_block_on_lease_never_ready(self, fake_sleep):
+        """``_block_on_lease`` - raises RuntimeError if the lease is never ready or an error"""
+        fake_lease = MagicMock()
+        fake_lease.state = 'foo'
+
+        with self.assertRaises(RuntimeError):
+            virtual_machine._block_on_lease(fake_lease)
+
+    @patch.object(virtual_machine.time, 'sleep')
+    def test_block_on_lease_never_ready(self, fake_sleep):
+        """``_block_on_lease`` - raises RuntimeError if the lease is never ready or an error"""
+        fake_lease = MagicMock()
+        fake_lease.state = 'foo'
+
+        try:
+            virtual_machine._block_on_lease(fake_lease)
+        except RuntimeError:
+            pass
+
+        sleep_call_count = fake_sleep.call_count
+        expected_call_count = 45
+        slept_for = sum([x[0][0] for x in fake_sleep.call_args_list])
+        expected_slept_for = 990 # seconds
+
+        self.assertEqual(sleep_call_count, expected_call_count)
+        self.assertEqual(slept_for, expected_slept_for)
+
+    @patch.object(virtual_machine, '_block_on_lease')
+    @patch.object(virtual_machine, 'get_vm_ovf_xml')
+    @patch.object(virtual_machine, 'download_vmdk')
+    @patch.object(virtual_machine, 'tarfile')
+    @patch.object(virtual_machine.os, 'makedirs')
+    @patch.object(virtual_machine.time, 'sleep')
+    @patch.object(virtual_machine, 'open')
+    @patch.object(virtual_machine.os, 'rename')
+    @patch.object(virtual_machine.os, 'listdir')
+    @patch.object(virtual_machine.shutil, 'rmtree')
+    def test_make_ova(self, fake_rmtree, fake_listdir, fake_rename, fake_open,
+        fake_sleep, fake_makedirs, fake_tarfile, fake_downlaod_vmdk, fake_get_vm_ovf_xml,
+        fake_block_on_lease):
+        """``make_ova`` - Returns the location of the new OVA file"""
+        fake_vcenter = MagicMock()
+        fake_vm = MagicMock()
+        fake_vm.name = 'myVM'
+        fake_log = MagicMock()
+
+        output = virtual_machine.make_ova(fake_vcenter, fake_vm, '/save/ova/here', fake_log)
+        expected = '/save/ova/here/myVM.ova'
+
+        self.assertEqual(output, expected)
+
+    @patch.object(virtual_machine, '_block_on_lease')
+    @patch.object(virtual_machine, 'get_vm_ovf_xml')
+    @patch.object(virtual_machine, 'download_vmdk')
+    @patch.object(virtual_machine, 'tarfile')
+    @patch.object(virtual_machine.os, 'makedirs')
+    @patch.object(virtual_machine.time, 'sleep')
+    @patch.object(virtual_machine, 'open')
+    @patch.object(virtual_machine.os, 'rename')
+    @patch.object(virtual_machine.os, 'listdir')
+    @patch.object(virtual_machine.shutil, 'rmtree')
+    def test_make_ova_downloads_all_vmdks(self, fake_rmtree, fake_listdir, fake_rename, fake_open,
+        fake_sleep, fake_makedirs, fake_tarfile, fake_download_vmdk, fake_get_vm_ovf_xml,
+        fake_block_on_lease):
+        """``make_ova`` - Downloads all the VMDKs of a virtual machine"""
+        fake_vcenter = MagicMock()
+        fake_vm = MagicMock()
+        fake_vm.name = 'myVM'
+        fake_vm.ExportVm.return_value.info.deviceUrl = ['https://foo.com', 'https://bar.com']
+        fake_log = MagicMock()
+
+        virtual_machine.make_ova(fake_vcenter, fake_vm, '/save/ova/here', fake_log)
+        vmdks_downloaded = fake_download_vmdk.call_count
+        expected = 2
+
+        self.assertEqual(vmdks_downloaded, expected)
+
+    @patch.object(virtual_machine, '_block_on_lease')
+    @patch.object(virtual_machine, 'get_vm_ovf_xml')
+    @patch.object(virtual_machine, 'download_vmdk')
+    @patch.object(virtual_machine, 'tarfile')
+    @patch.object(virtual_machine.os, 'makedirs')
+    @patch.object(virtual_machine.time, 'sleep')
+    @patch.object(virtual_machine, 'open')
+    @patch.object(virtual_machine.os, 'rename')
+    @patch.object(virtual_machine.os, 'listdir')
+    @patch.object(virtual_machine.shutil, 'rmtree')
+    def test_make_ova_adds_all_files(self, fake_rmtree, fake_listdir, fake_rename, fake_open,
+        fake_sleep, fake_makedirs, fake_tarfile, fake_download_vmdk, fake_get_vm_ovf_xml,
+        fake_block_on_lease):
+        """``make_ova`` - adds all files to the OVA"""
+        fake_vcenter = MagicMock()
+        fake_vm = MagicMock()
+        fake_vm.name = 'myVM'
+        fake_log = MagicMock()
+        fake_listdir.return_value = ['myVM.ovf', 'disk-0.vmdk']
+
+        virtual_machine.make_ova(fake_vcenter, fake_vm, '/save/ova/here', fake_log)
+        files_added_to_ova = fake_tarfile.open.return_value.add.call_count
+        expected = 2
+
+        self.assertEqual(files_added_to_ova, expected)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/vlab_inf_common/vmware/vcenter.py
+++ b/vlab_inf_common/vmware/vcenter.py
@@ -285,6 +285,17 @@ class vCenter(object):
         """
         return self._conn.content.ovfManager
 
+    def cookie(self):
+        """Obtain the cookie used to validate/authorize the connection to vCenter.
+
+        :Returns: Dictionary
+        """
+        soap_cookie = self._conn._stub.cookie.split(';')[0]
+        name, value = soap_cookie.split('=')
+        value = value.replace('"', '') # the cookie value is surrounded by quotas.
+        return {name: value}
+
+
     def __enter__(self):
         return self
 

--- a/vlab_inf_common/vmware/virtual_machine.py
+++ b/vlab_inf_common/vmware/virtual_machine.py
@@ -883,6 +883,7 @@ def make_ova(vcenter, the_vm, template_dir, log):
     :type log: logging.Logger
     """
     ova_location = ''
+    power(the_vm, 'off')
     lease = the_vm.ExportVm()
     _block_on_lease(lease)
     with ProgressChimer(lease, log):

--- a/vlab_inf_common/vmware/virtual_machine.py
+++ b/vlab_inf_common/vmware/virtual_machine.py
@@ -893,10 +893,10 @@ def make_ova(vcenter, the_vm, template_dir, log):
         for device in lease.info.deviceUrl:
             device_ovf = download_vmdk(save_location, vcenter.cookie(), device, log)
             device_ovfs.extend(device_ovf)
-        vm_ovf_xml = get_vm_ovf_xml(the_vm, device_ovfs, vcenter)
-        ovf_xml_file = os.path.join(save_location, the_vm.name, '.ovf')
-        with open(ovf_xml_file, 'w') as the_file:
-            the_file.write(vm_ovf_xml)
+    vm_ovf_xml = get_vm_ovf_xml(the_vm, device_ovfs, vcenter)
+    ovf_xml_file = os.path.join(save_location, the_vm.name, '.ovf')
+    with open(ovf_xml_file, 'w') as the_file:
+        the_file.write(vm_ovf_xml)
     # Convert to OVA
     ova_name = '{}.ova'.format(the_vm.name)
     ova = tarfile.open(ova_name)

--- a/vlab_inf_common/vmware/virtual_machine.py
+++ b/vlab_inf_common/vmware/virtual_machine.py
@@ -4,9 +4,12 @@ Common functions for interacting with Virtual Machines in VMware
 """
 import ssl
 import time
+import shutil
 import random
 import os.path
+import tarfile
 import textwrap
+import threading
 from io import BytesIO
 
 import ujson
@@ -15,8 +18,8 @@ import requests
 from pyVmomi import vim
 from urllib3.exceptions import InsecureRequestWarning
 
-from vlab_inf_common.vmware import consume_task
 from vlab_inf_common.constants import const
+from vlab_inf_common.vmware.tasks import consume_task
 from vlab_inf_common.vmware.exceptions import DeployFailure
 
 requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
@@ -727,3 +730,179 @@ def _get_upload_url(vcenter, the_vm, creds, upload_path, file_size, file_attribu
     else:
         error = 'Unable to file to VM. Timed out waiting on GuestOperations to become available.'
         raise ValueError(error)
+
+
+def download_vmdk(save_location, http_cookies, device, log):
+    """Copy the VMDK of a virtual machine to the local filesystem.
+
+    The returned list will be either empty (falsy), or contain an OVF object for
+    the VMDK. Because the caller must construct a list of OVF objects for *all*
+    devices in a VM, just extend the list in your code with what this function
+    returns.
+
+    :Returns: List
+
+    :param save_location: The directory to save the VMDK file to.
+    :type save_location: String
+
+    :param http_cookies: The vCenter SOAP auth cookie(s) to use.
+    :type http_cookies: Dictionary
+
+    :param device: A component of the virtual machine to download.
+    :type device: vim.HttpNfcLease.DeviceUrl
+
+    :param log: An object for writing debug/progress messages.
+    :type log: logging.Logger
+    """
+    vmdk_obj = []
+    if not (device.disk and device.taretId):
+        log.error("Device is not a VMDK: %s", device.url)
+    else:
+        vmdk_file = os.path.join(save_location, device.targetId)
+        with open(vmdk_file, 'wb') as the_file:
+            resp = requests.get(device.url,
+                                stream=True,
+                                headers={'Accept': 'application/x-vnd.vmware-streamVmdk'},
+                                cookies=http_cookies,
+                                verify=False)
+            resp.raise_for_status()
+            bytes_written = 0
+            for block in resp.iter_content(chunk_size=20480):
+                if block:
+                    # filter out keep-alive chunks
+                    the_file.write(block)
+                    bytes_written += len(block)
+        # Create the OVF object; needed to create the correct XML for the whole machine
+        ovf_file = vim.OvfManager.OvfFile()
+        ovf_file.deviceId = device.key
+        ovf_file.path = device.targetId
+        ovf_file.size = bytes_written
+        vmdk_obj.append(ovf_file)
+    return vmdk_obj
+
+
+def get_vm_ovf_xml(vm, device_ovfs, vcenter):
+    """Obtain the XML that defines a virtual machine's OVF.
+
+    :Returns: String (xml)
+
+    :param vm: The virtual machine object to obtain the OVF XML for.
+    :type vm: vim.VirtualMachine
+
+    :param device_ovfs: The device-specific OVFs of the virtual machine (vm).
+    :type device_ovfs: List
+
+    :param vcenter: A valid connection to a vCenter server.
+    :type vcenter: vlab_inf_common.vmware.vCenter
+    """
+    ovf_params = vim.OvfManager.CreateDescriptorParams()
+    ovf_params.name = vm.name
+    ovf_params.ovfFiles = device_ovfs
+    vm_ovf = vcenter.content.ovfManager.CreateDescriptor(obj=vm, cdp=ovf_params)
+    if vm_ovf.error:
+        raise vm_ovf.error[0].fault
+    return vm_ovf.ovfDescriptor
+
+
+class ProgressChimer(threading.Thread):
+    """Keeps the lease alive while downloading a VMDK from vSphere.
+
+    Using in a ``with`` statement ensures the lease is closed, and makes your code
+    cleaner!
+
+    :param lease: Required to export a VM to an OVA.
+    :type lease: vim.HttpNfcLease
+
+    :param log: An object for writing debug/progress messages.
+    :type log: logging.Logger
+
+    :param update_interval: How often renew/update the lease, in seconds.
+    :type update_interval: Integer
+    """
+    def __init__(self, lease, log, update_interval=10):
+        super().__init__()
+        self._lease = lease
+        self._keep_running = True
+        self._update_interval = update_interval
+        self.start()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exce_type, exec_value, exce_traceback):
+        self.complete()
+
+    def complete(self):
+        self._lease.HttpNfcLeaseProgress(100)
+        self._lease.HttpNfcLeaseComplete()
+        self._keep_running = False
+        self.join()
+
+    def run(self):
+        while self._keep_running:
+            self._lease.HttpNfcLeaseProgress(50)
+            time.sleep(self._update_interval)
+
+
+def _block_on_lease(lease):
+    """Blocks execution until the lease is usable or fails
+
+    :Returns: None
+
+    :param lease: Required to export a VM to an OVA.
+    :type lease: vim.HttpNfcLease
+    """
+    # this amounts to waiting upwards of 990 seconds, with linear backoff
+    for i in range(45):
+        if lease.state == vim.HttpNfcLease.State.ready:
+            break
+        elif lease.state == vim.HttpNfcLease.State.error:
+            raise RuntimeError("VM Export lease error: {}".format(lease.state.error))
+        else:
+            time.sleep(i)
+    else:
+        raise RuntimeError("Lease never became ready")
+
+
+def make_ova(vcenter, the_vm, template_dir, log):
+    """Export a virtual machine into an OVA. The returned string is the location
+    of the new OVA file.
+
+    :Returns: String
+
+    :param vcenter: The instantiated connection to vCenter
+    :type vcenter: vlab_inf_common.vmware.vCenter
+
+    :param the_vm: The name of the VM
+    :type the_vm: String
+
+    :param template_dir: The folder to save the new OVA to.
+    :type template_dir: String
+
+    :param log: A message for writing progress/debug messages.
+    :type log: logging.Logger
+    """
+    ova_location = ''
+    lease = the_vm.ExportVm()
+    _block_on_lease(lease)
+    with ProgressChimer(lease, log):
+        save_location = os.path.join(template_dir, the_vm.name)
+        os.makedirs(save_location, exists_ok=True)
+        device_ovfs = []
+        for device in lease.info.deviceUrl:
+            device_ovf = download_vmdk(save_location, vcenter.cookie(), device, log)
+            device_ovfs.extend(device_ovf)
+        vm_ovf_xml = get_vm_ovf_xml(the_vm, device_ovfs, vcenter)
+        ovf_xml_file = os.path.join(save_location, the_vm.name, '.ovf')
+        with open(ovf_xml_file, 'w') as the_file:
+            the_file.write(vm_ovf_xml)
+    # Convert to OVA
+    ova_name = '{}.ova'.format(the_vm.name)
+    ova = tarfile.open(ova_name)
+    for ova_file in os.listdir(save_location):
+        ova.add(ova_file, arcname=os.path.basename(ova_file))
+    ova.close()
+    ova_location = os.path.join(template_dir, ova_name)
+    os.rename(ova_name, ova_location)
+    shutil.rmtree(save_location)
+    return ova_location


### PR DESCRIPTION
I'm sure there are some bugs in this still. However, at this point it all _looks good_ to my eyes, and doesn't blow up.

The idea is that if you have a VM and vCenter object, then you can call `make_ova` from the `virtual_machine` module to an OVA of the machine to the local file system. I used [this code](https://github.com/vmware/pyvmomi-community-samples/blob/master/samples/export_vm.py) for as an implementation reference. 

A short snippet of using this feature is:
```
import logging
from vlab_inf_common.vmware import vCenter, virtual_machine, vim

logger = logging.getLogger()

def foo(logger):
    with vCenter(host='my-vcenter.org' user='admin@vsphere.local', password='iLoveKatz!') as vcenter:
        vm = vcenter.get_by_name(name='myCoolVM', vimtype=vim.VirtualMachine)
        ova_path = virtual_machine.make_ova(vcenter, vm, '/save/ova/here/', logger)
        virtual_machine.power(vm, 'on') # assuming you want the VM powered back on.
        return ova_path
```

Like the rest of the vmware stuff, I try to abstract away the _"Python-Java"_ of the PyVmomi library. 