### PR TITLE
make_ova now allows caller to specify the name of the OVA file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2020.11.11',
+      version='2020.11.12',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/tests/test_virtual_machine.py
+++ b/tests/test_virtual_machine.py
@@ -1101,6 +1101,56 @@ class TestVMExportFunctions(unittest.TestCase):
 
         self.assertEqual(the_args, expected)
 
+    @patch.object(virtual_machine, 'power')
+    @patch.object(virtual_machine, '_block_on_lease')
+    @patch.object(virtual_machine, 'get_vm_ovf_xml')
+    @patch.object(virtual_machine, 'download_vmdk')
+    @patch.object(virtual_machine, 'tarfile')
+    @patch.object(virtual_machine.os, 'makedirs')
+    @patch.object(virtual_machine.time, 'sleep')
+    @patch.object(virtual_machine, 'open')
+    @patch.object(virtual_machine.os, 'rename')
+    @patch.object(virtual_machine.os, 'listdir')
+    @patch.object(virtual_machine.shutil, 'rmtree')
+    def test_make_ova_provide_name(self, fake_rmtree, fake_listdir, fake_rename, fake_open,
+        fake_sleep, fake_makedirs, fake_tarfile, fake_download_vmdk, fake_get_vm_ovf_xml,
+        fake_block_on_lease, fake_power):
+        """``make_ova`` - Allows the caller to define the name of the OVA file."""
+        fake_vcenter = MagicMock()
+        fake_vm = MagicMock()
+        fake_vm.name = 'myVM'
+        fake_log = MagicMock()
+
+        output = virtual_machine.make_ova(fake_vcenter, fake_vm, '/save/ova/here', fake_log, ova_name='vm01.ova')
+        expected = '/save/ova/here/vm01.ova'
+
+        self.assertEqual(output, expected)
+
+    @patch.object(virtual_machine, 'power')
+    @patch.object(virtual_machine, '_block_on_lease')
+    @patch.object(virtual_machine, 'get_vm_ovf_xml')
+    @patch.object(virtual_machine, 'download_vmdk')
+    @patch.object(virtual_machine, 'tarfile')
+    @patch.object(virtual_machine.os, 'makedirs')
+    @patch.object(virtual_machine.time, 'sleep')
+    @patch.object(virtual_machine, 'open')
+    @patch.object(virtual_machine.os, 'rename')
+    @patch.object(virtual_machine.os, 'listdir')
+    @patch.object(virtual_machine.shutil, 'rmtree')
+    def test_make_ova_provide_name_extension(self, fake_rmtree, fake_listdir, fake_rename, fake_open,
+        fake_sleep, fake_makedirs, fake_tarfile, fake_download_vmdk, fake_get_vm_ovf_xml,
+        fake_block_on_lease, fake_power):
+        """``make_ova`` - Appends '.ova' extension to a VM name if needed"""
+        fake_vcenter = MagicMock()
+        fake_vm = MagicMock()
+        fake_vm.name = 'myVM'
+        fake_log = MagicMock()
+
+        output = virtual_machine.make_ova(fake_vcenter, fake_vm, '/save/ova/here', fake_log, ova_name='vm01')
+        expected = '/save/ova/here/vm01.ova'
+
+        self.assertEqual(output, expected)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/vlab_inf_common/vmware/virtual_machine.py
+++ b/vlab_inf_common/vmware/virtual_machine.py
@@ -864,7 +864,7 @@ def _block_on_lease(lease):
         raise RuntimeError("Lease never became ready")
 
 
-def make_ova(vcenter, the_vm, template_dir, log):
+def make_ova(vcenter, the_vm, template_dir, log, ova_name=''):
     """Export a virtual machine into an OVA. The returned string is the location
     of the new OVA file.
 
@@ -881,6 +881,9 @@ def make_ova(vcenter, the_vm, template_dir, log):
 
     :param log: A message for writing progress/debug messages.
     :type log: logging.Logger
+
+    :param ova_name: Optionally define the name for the OVA. Defaults to the name of the VM.
+    :type ova_name: String
     """
     ova_location = ''
     power(the_vm, 'off')
@@ -898,7 +901,11 @@ def make_ova(vcenter, the_vm, template_dir, log):
     with open(ovf_xml_file, 'w') as the_file:
         the_file.write(vm_ovf_xml)
     # Convert to OVA
-    ova_name = '{}.ova'.format(the_vm.name)
+    if not ova_name:
+        ova_name = '{}.ova'.format(the_vm.name)
+    else:
+        if not ova_name.endswith('.ova'):
+            ova_name = '{}.ova'.format(ova_name)
     ova = tarfile.open(ova_name)
     for ova_file in os.listdir(save_location):
         ova.add(ova_file, arcname=os.path.basename(ova_file))


### PR DESCRIPTION
I need this for the vlab deployments feature. Deploying a template appends `-dply` to the VM name in hopes of avoiding a name collision. This means that I also have to strip `-dply` off the OVA name when creating a template. If we don't strip that off the VM name when creating a template, then we'll end up with crazy long names as users create new templates from existing deployments.