### PR TITLE
Added function to provision a new VMDK for an existing virtual machine

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2020.11.24',
+      version='2021.01.14',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/tests/test_virtual_machine.py
+++ b/tests/test_virtual_machine.py
@@ -803,17 +803,6 @@ class TestConfigStaticIP(unittest.TestCase):
                                             fake_file_size,
                                             fake_file_attributes)
 
-
-
-
-
-
-
-
-
-
-
-
     @patch.object(virtual_machine, 'consume_task')
     def test_add_vmdk(self, fake_consume_task):
         """``add_vmdk`` Blocks on adding an extra VMDK to the DataIQ machine"""
@@ -862,8 +851,6 @@ class TestConfigStaticIP(unittest.TestCase):
         thin_provision = fake_the_vm.ReconfigVM_Task.call_args[1]['spec'].deviceChange[0].device.backing.thinProvisioned
 
         self.assertTrue(thin_provision)
-
-
 
 
 class TestVMExportFunctions(unittest.TestCase):

--- a/tests/test_virtual_machine.py
+++ b/tests/test_virtual_machine.py
@@ -803,6 +803,69 @@ class TestConfigStaticIP(unittest.TestCase):
                                             fake_file_size,
                                             fake_file_attributes)
 
+
+
+
+
+
+
+
+
+
+
+
+    @patch.object(virtual_machine, 'consume_task')
+    def test_add_vmdk(self, fake_consume_task):
+        """``add_vmdk`` Blocks on adding an extra VMDK to the DataIQ machine"""
+        fake_dev = MagicMock()
+        fake_the_vm = MagicMock()
+        fake_the_vm.config.hardware.device = [fake_dev]
+        disk_size = 1
+
+        virtual_machine.add_vmdk(fake_the_vm, disk_size)
+
+        self.assertTrue(fake_consume_task.called)
+
+    @patch.object(virtual_machine, 'consume_task')
+    def test_add_vmdk_too_many_vmdks(self, fake_consume_task):
+        """``add_vmdk`` Raises RuntimeError if there are 16 or more VMDKs"""
+        fake_dev = MagicMock()
+        fake_dev.unitNumber = 15
+        fake_the_vm = MagicMock()
+        fake_the_vm.config.hardware.device = [fake_dev]
+        disk_size = 1
+
+        with self.assertRaises(RuntimeError):
+            virtual_machine.add_vmdk(fake_the_vm, disk_size)
+
+    @patch.object(virtual_machine, 'consume_task')
+    def test_add_vmdk_no_vmdks(self, fake_consume_task):
+        """``add_vmdk`` Raises RuntimeError if there zero VMDKs"""
+        fake_the_vm = MagicMock()
+        fake_the_vm.config.hardware.device = []
+        disk_size = 1
+
+        with self.assertRaises(RuntimeError):
+            virtual_machine.add_vmdk(fake_the_vm, disk_size)
+
+    @patch.object(virtual_machine, 'consume_task')
+    def test_add_vmdk_thin(self, fake_consume_task):
+        """``add_vmdk`` Creates a thin-provisioned VMDK"""
+        fake_dev = MagicMock()
+        fake_dev.unitNumber = 6
+        fake_the_vm = MagicMock()
+        fake_the_vm.config.hardware.device = [fake_dev]
+        disk_size = 1
+
+        virtual_machine.add_vmdk(fake_the_vm, disk_size)
+
+        thin_provision = fake_the_vm.ReconfigVM_Task.call_args[1]['spec'].deviceChange[0].device.backing.thinProvisioned
+
+        self.assertTrue(thin_provision)
+
+
+
+
 class TestVMExportFunctions(unittest.TestCase):
     """A suite of test cases for functions used to create an OVA from an virtual machine"""
 


### PR DESCRIPTION
Some OVAs require a sysadmin to add a VMDK at _deploy time_. This way, the sysadmin can provision disk space that makes sense for their environment/needs. Centralizing this logic here makes more sense than having several variants across different services.