### PR TITLE
Fixed race between upload progress chimer, and compleating an upload lease

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2021.02.19',
+      version='2021.04.02',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/vlab_inf_common/vmware/ova.py
+++ b/vlab_inf_common/vmware/ova.py
@@ -116,6 +116,7 @@ class Ova(object):
             self._chime_progress(lease)
             for file_item in self._spec.fileItem:
                 self._upload_disk(file_item)
+            self._lease.Progress(100.0)
             self._lease.Complete()
         except vmodl.MethodFault as doh:
             lease.Abort(doh)

--- a/vlab_inf_common/vmware/ova.py
+++ b/vlab_inf_common/vmware/ova.py
@@ -116,7 +116,7 @@ class Ova(object):
             self._chime_progress(lease)
             for file_item in self._spec.fileItem:
                 self._upload_disk(file_item)
-            self._lease.Progress(100.0)
+            self._lease.Progress(100)
             self._lease.Complete()
         except vmodl.MethodFault as doh:
             lease.Abort(doh)


### PR DESCRIPTION
Yeah, so a bit surprised it took _this long_ to find this bug.

Turns out, the Chimer that pings vCenter with the upload process of the OVA can race with the actual upload. Like, the OVA can be uploaded completely so we call `Complete()` on the lease before the Chimer notifies vCenter that it's at 100%. Given that the Chimer only runs once every 5 seconds, I'm shocked this hasn't happened before!

Simple enough fix; update progress to 100% and complete the lease at the end of the _upload disks_ loop. As long as progress doesn't go _backwards_ VMware wont care if the Chimer also signals 100% inbetween the _upload disks_ loop signaling 100%, and then it calling `Complete()` on the lease.