### PR TITLE
VMWARE!!!!

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2021.04.02',
+      version='2021.04.13',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/vlab_inf_common/vmware/ova.py
+++ b/vlab_inf_common/vmware/ova.py
@@ -239,7 +239,8 @@ class FileHandle(object):
 
     # A slightly more accurate percentage
     def progress(self):
-        return int(100.0 * self.offset / self.st_size)
+        prog = int(100.0 * self.offset / self.st_size)
+        return min(prog, 100.0)
 
 
 class WebHandle(object):
@@ -299,4 +300,5 @@ class WebHandle(object):
 
     # A slightly more accurate percentage
     def progress(self):
-        return int(100.0 * self.offset / self.st_size)
+        prog = int(100.0 * self.offset / self.st_size)
+        return min(prog, 100.0)


### PR DESCRIPTION
This would be simpler to debug if the damn error said either:

* **WHY** the parameter was invalid
-or-
* **WHAT** the invalid value was

Here's what you get... 😒:
```
onefs-worker_1       | [2021-04-13 19:41:27,466: INFO/ForkPoolWorker-1] Task starting
onefs-worker_1       | [2021-04-13 19:41:52,753: WARNING/ForkPoolWorker-8] Traceback (most recent call last):
onefs-worker_1       |   File "/usr/local/lib/python3.8/dist-packages/vlab_inf_common/vmware/ova.py", line 184, in _timer
onefs-worker_1       |     lease.Progress(prog)
onefs-worker_1       |   File "/usr/local/lib/python3.8/dist-packages/pyVmomi/VmomiSupport.py", line 706, in <lambda>
onefs-worker_1       |     self.f(*(self.args + (obj,) + args), **kwargs)
onefs-worker_1       |   File "/usr/local/lib/python3.8/dist-packages/pyVmomi/VmomiSupport.py", line 512, in _InvokeMethod
onefs-worker_1       |     return self._stub.InvokeMethod(self, info, args)
onefs-worker_1       |   File "/usr/local/lib/python3.8/dist-packages/pyVmomi/SoapAdapter.py", line 1397, in InvokeMethod
onefs-worker_1       |     raise obj # pylint: disable-msg=E0702
onefs-worker_1       | pyVmomi.VmomiSupport.vmodl.fault.InvalidArgument: (vmodl.fault.InvalidArgument) {
onefs-worker_1       |    dynamicType = <unset>,
onefs-worker_1       |    dynamicProperty = (vmodl.DynamicProperty) [],
onefs-worker_1       |    msg = 'A specified parameter was not correct: percent',
onefs-worker_1       |    faultCause = <unset>,
onefs-worker_1       |    faultMessage = (vmodl.LocalizableMessage) [],
onefs-worker_1       |    invalidProperty = 'percent'
onefs-worker_1       | }
```

Why even bother. I mean, it's just as meaningful as "Error: An error has occurred."