### PR TITLE
VM names must adhere to hostname char requirements now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-inf-common",
       author="Nicholas Willhite, Kevin Broadware",
       author_email='willnx84@gmail.com',
-      version='2021.04.27',
+      version='2021.05.03',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/vlab_inf_common/vmware/virtual_machine.py
+++ b/vlab_inf_common/vmware/virtual_machine.py
@@ -2,6 +2,7 @@
 """
 Common functions for interacting with Virtual Machines in VMware
 """
+import re
 import ssl
 import time
 import shutil
@@ -352,6 +353,11 @@ def deploy_from_ova(vcenter, ova, network_map, username, machine_name, logger, p
     """
     if not isinstance(network_map, list):
         raise ValueError('Param network_map must be of type list, found {}'.format(type(network_map)))
+
+    hostname_regex = r'^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$'
+    if not re.match(hostname_regex, machine_name):
+        error = 'Invalid name for machine. Names can only contain characters a-z, A-Z, 0-9, periods (".") and dashes ("-"). Supplied: {}'.format(machine_name)
+        raise ValueError(error)
 
     folder = vcenter.get_by_name(name=username, vimtype=vim.Folder)
     resource_pool = vcenter.resource_pools[const.INF_VCENTER_RESORUCE_POOL]

--- a/vlab_inf_common/vmware/virtual_machine.py
+++ b/vlab_inf_common/vmware/virtual_machine.py
@@ -356,7 +356,7 @@ def deploy_from_ova(vcenter, ova, network_map, username, machine_name, logger, p
 
     hostname_regex = r'^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$'
     if not re.match(hostname_regex, machine_name):
-        error = 'Invalid name for machine. Names can only contain characters a-z, A-Z, 0-9, periods (".") and dashes ("-"). Supplied: {}'.format(machine_name)
+        error = 'Invalid machine name. Names can only contain characters a-z, A-Z, 0-9, periods (".") and dashes ("-"). Supplied: {}'.format(machine_name)
         raise ValueError(error)
 
     folder = vcenter.get_by_name(name=username, vimtype=vim.Folder)


### PR DESCRIPTION
The title says it all!

Generally speaking, it's just a good habit to make VM names in vSphere match the literal machine's hostname. Beyond that, it fixes a bug where vLab can't find a machine when it has a space in the name.